### PR TITLE
fix: add failing test case for the double resolve issue

### DIFF
--- a/auth/proxy/proxy.ts
+++ b/auth/proxy/proxy.ts
@@ -95,16 +95,6 @@ async function _proxyRequest(
             req.write(body);
         }
 
-        // req.setTimeout(10000, () => {
-        //     console.error("Request to Cognito timed out");
-        //     safeResolve({
-        //         statusCode: 500,
-        //         headers: { 'Content-Type': 'application/x-amz-json-1.1' },
-        //         body: JSON.stringify({ message: 'Internal server error' })
-        //     });
-        //     req.destroy();
-        // });
-
         req.end();
     });
 }

--- a/auth/proxy/tests/unit/proxy.unit.test.ts
+++ b/auth/proxy/tests/unit/proxy.unit.test.ts
@@ -98,8 +98,8 @@ describe('proxy', () => {
             requestFn: mockRequest
         })) as APIGatewayProxyStructuredResultV2;
 
-        expect(response.statusCode).toBe(200);
-        expect(response.body).toContain('foo');
+        expect(response.statusCode).toBe(500);
+        expect(JSON.parse(response.body as string)).toEqual({"message":"Internal server error"});
     });
 
     it('returns 500 on proxy error', async () => {


### PR DESCRIPTION
## 🧗 Edge-case: Double-resolution - async event handlers

* A promise can only be resolved/rejected once - if `resolve()` is called from two different asynchronous events, there's a potential race condition (as to which one runs first)
* And, this may cause the request to return two different responses

#### Example Scenario

1. `https.request()` triggers the `'end'` event: the proxy function resolves with status `200`, returns data to the client.
2. But, 10ms later, `'error'` is emitted — maybe a socket issue or timeout.
3. Without guarding:
* We call `resolve()` again — second response.
* Depending on the runtime, this might:
  * Throw an error (bad)
  * Be silently ignored (confusing)
  * Log an error that doesn’t reflect the real outcome (very confusing)

With the guard (`let resolved = false`), the second call is ignored cleanly. The function resolves once, cleanly, avoiding downstream issues.

Even though JS doesn't crash when a Promise is resolved more than once, **it can lead to:**

* Unexpected logging ("why did an error happen after a success?")
* Inconsistent state if code downstream expects only one branch to run
* Hard-to-debug race conditions when results differ based on timing

In a test or production environment, this might manifest like:

```bash
Proxy succeeded...
Error proxying request to Cognito: Simulated error
```

The logs would be misleading: a successful result was returned, but an error still fired later.

##### How to Guard Against It
We can prevent this with a guard variable:

```ts
let resolved = false;
const safeResolve = (value) => {
  if (!resolved) {
    resolved = true;
    resolve(value);
  }
};
```

Now, even if both 'end' and 'error' happen:

```ts
safeResolve(success)   // ✅ resolves
safeResolve(error)     // ❌ ignored, resolved already
```

**Note:** This doesn't guarantee which promise resolves first - (`error` may resolve before `end`) but does guarantee that only one request is sent back to the client.

### Rabbit Hole: Should we resolve based on the last event instead of the first? 🐰 

> Because what if the success fires, then we find out the connection errored — wouldn’t we be misleading the client?

#### Are HTTP Events Ordered?
Yes — within a single request, Node.js stream events like `'data'`, `'end'`, `'error'` have a predictable order:

* `'data'` → `'end'` → done ✅
* OR: `'error'` at any time → failure ❌
* But you won’t normally get `'end'` and then `'error'` — that would be unusual, but possible in mocks or corrupted conditions.

A good principle is:

> Whichever event fires first — error or end — determines the result.

But most libraries typically treat `'error'` as more fatal, because:

* You might have partial data
* The stream is corrupted
* You can't trust 'end' anymore

Pattern of resolving on the first event is correct — as long as:

* You guard against double-resolve
* You handle 'error' seriously, even if 'end' also fires
