### PR TITLE
feat: handle request write errors

### DIFF
--- a/auth/proxy/proxy.ts
+++ b/auth/proxy/proxy.ts
@@ -73,8 +73,18 @@ async function _proxyRequest(hostname: string, path: string, body: any, headers:
             });
         });
 
-        if (method === 'POST' && body) {
-            req.write(body);
+        try {
+            if (method === 'POST' && body) {
+                req.write(body);
+            }
+        } catch (e) {
+            console.error('Error during req.write:', e);
+            resolve({
+                statusCode: 500,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: 'Internal server error' }),
+            });
+            return;
         }
 
         req.end();


### PR DESCRIPTION
## Description

### 🧗 Edge-case: Handle request writing errors

* Throwing due to an invalid body (like an object instead of a string, or a low-level socket error).

