### PR TITLE
fix: auth proxy secret permissions and secret name reference

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -916,7 +916,7 @@ Resources:
             - Effect: Allow
               Action:
                 - secretsmanager:GetSecretValue # pragma: allowlist secret
-              Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/cognito/client-secret
+              Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/cognito/client-secret-*
       Environment:
         Variables:
           ENABLE_ATTESTATION: !Sub "{{resolve:ssm:/${ConfigStackName}/feature-flags/attestation}}"
@@ -934,7 +934,7 @@ Resources:
                 - !Sub ".auth.${AWS::Region}.amazoncognito.com"
           FIREBASE_IOS_APP_ID: !Sub "{{resolve:ssm:/${ConfigStackName}/firebase/appcheck/ios-app-id}}"
           FIREBASE_ANDROID_APP_ID: !Sub "{{resolve:ssm:/${ConfigStackName}/firebase/appcheck/android-app-id}}"
-          COGNITO_SECRET_NAME: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/cognito/client-secret
+          COGNITO_SECRET_NAME: !Sub /${ConfigStackName}/cognito/client-secret
       Tags:
         Product: GOV.UK
         Environment: !Ref Environment

--- a/auth/tests/unit/attestation.unit.test.ts
+++ b/auth/tests/unit/attestation.unit.test.ts
@@ -52,7 +52,7 @@ describe("attestation", () => {
     it("contains a reference to the cognito secret name", () => {
       expect(resourceUnderTest.Properties.Environment.Variables).containSubset({
         COGNITO_SECRET_NAME: {
-          "Fn::Sub": "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/cognito/client-secret",
+          "Fn::Sub": "/${ConfigStackName}/cognito/client-secret",
         },
       });
     });
@@ -67,7 +67,7 @@ describe("attestation", () => {
               ],
               "Effect": "Allow",
               "Resource": {
-                "Fn::Sub": "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/cognito/client-secret",
+                "Fn::Sub": "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/cognito/client-secret-*",
               },
             },
           ],


### PR DESCRIPTION
## Description

Auth-proxy getting `access-denied exception`'s when accessing the secret as a result of the changing of secrets/parameter prefix [here](https://github.com/alphagov/govuk-mobile-backend-ssm/pull/16). 
