### PR TITLE
BAU: Reference UserPoolIdentityProvider in CognitoUserPoolClient to avoid a race condition

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -141,7 +141,7 @@ Resources:
                           - "/"
                           - Ref: AWS::StackId
       SupportedIdentityProviders:
-        - onelogin
+        - !Ref UserPoolIdentityProvider
       AllowedOAuthFlows:
         - code
       AllowedOAuthScopes:
@@ -838,7 +838,7 @@ Resources:
           - app.ts
 
   UserPoolIdentityProvider:
-    Type: "AWS::Cognito::UserPoolIdentityProvider"
+    Type: AWS::Cognito::UserPoolIdentityProvider
     Properties:
       UserPoolId: !Ref CognitoUserPool
       ProviderName: "onelogin"

--- a/auth/tests/unit/cognito-client-oidc.unit.test.ts
+++ b/auth/tests/unit/cognito-client-oidc.unit.test.ts
@@ -15,7 +15,9 @@ describe("Set up the Cognito User Pool OIDC client", () => {
 
   it("has onelogin as IDP", () => {
     template.hasResourceProperties("AWS::Cognito::UserPoolClient", {
-      SupportedIdentityProviders: ["onelogin"],
+      SupportedIdentityProviders: [{
+        Ref: "UserPoolIdentityProvider"
+      }],
     });
   });
 


### PR DESCRIPTION
The pool client needs to reference the identity provider to ensure the provider gets created first.