### PR TITLE
Fix: lambda proxy integration functions must be async or will return 502

### DIFF
--- a/auth/shared-signals/app.ts
+++ b/auth/shared-signals/app.ts
@@ -8,7 +8,8 @@ import type { APIGatewayProxyResult } from 'aws-lambda';
  * Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
  * @returns object - API Gateway Lambda Proxy Output Format
  */
-export const lambdaHandler = (): APIGatewayProxyResult => {
+// eslint-disable-next-line @typescript-eslint/require-await
+export const lambdaHandler = async (): Promise<APIGatewayProxyResult> => {
     console.log("Shared signals receiver called")
     return {
         statusCode: 200,
@@ -16,5 +17,4 @@ export const lambdaHandler = (): APIGatewayProxyResult => {
             message: 'signal received',
         }),
     };
-
 };


### PR DESCRIPTION
Shared signals lambda has been returning 502 with the error:

```
Tue May 27 10:59:31 UTC 2025 : Endpoint response body before transformations: null
Tue May 27 10:59:31 UTC 2025 : Execution failed due to configuration error: Malformed Lambda proxy response
Tue May 27 10:59:31 UTC 2025 : Method completed with status: 502
```

As a result of converting the Shared signals lambda function to a synchronous handler .