### PR TITLE
fix: update IAM role to use PermissionsBoundary

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -827,6 +827,10 @@ Resources:
                       - Fn::Split:
                           - "/"
                           - Ref: AWS::StackId
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/auth/tests/unit/cognito-throttles-cloudwatch-alarms.test.ts
+++ b/auth/tests/unit/cognito-throttles-cloudwatch-alarms.test.ts
@@ -175,6 +175,11 @@ describe.each(testCases)(
           Ref: "CloudWatchAlarmFederationThrottlesTopicPagerDuty",
         },
       ]);
+      expect(slackChannelConfigurationUnderTest.Properties.Tags).toEqual([
+        { Key: "Product", Value: "GOV.UK" },
+        { Key: "Environment", Value: { Ref: "Environment" } },
+        { Key: "System", Value: "Authentication" },
+      ]);
     });
 
     it("should have a Slack Channel IAM Role", () => {
@@ -208,6 +213,11 @@ describe.each(testCases)(
           },
         ],
       });
+      expect(slackChannelIAMRoleUnderTest.Properties.Tags).toEqual([
+        { Key: "Product", Value: "GOV.UK" },
+        { Key: "Environment", Value: { Ref: "Environment" } },
+        { Key: "System", Value: "Authentication" },
+      ]);
     });
 
     it(`should create a CloudWatch alarm for ${metricName}`, () => {


### PR DESCRIPTION
## Description
Fixes the deployment issue around creating the IAM Role for the Slack Config

JIra Ticket [GOVUKAPP-1761](https://govukverify.atlassian.net/browse/GOVUKAPP-1761)

[GOVUKAPP-1761]: https://govukverify.atlassian.net/browse/GOVUKAPP-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ