### PR TITLE
fix: allow application json content type header

### DIFF
--- a/auth/proxy/header-schema.json
+++ b/auth/proxy/header-schema.json
@@ -1,41 +1,45 @@
 {
-   "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "type": "object",
-   "properties": {
-      "content-type": {
-         "type": "string",
-         "enum": [
-            "application/x-www-form-urlencoded",
-            "application/json"
-         ]
-      },
-      "x-attestation-token": {
-         "type": "string",
-         "pattern": "^[\\x00-\\x7F]*$"
-      },
-      "accept": {
-         "description": "Client's preferred response format from Cognito.",
-         "type": "string",
-         "maxLength": 1024,
-         "pattern": "^[\\x00-\\x7F]*$"
-      },
-      "user-agent": {
-         "description": "Identifies the client or proxy software making the request.",
-         "type": "string",
-         "maxLength": 1024,
-         "pattern": "^[\\x00-\\x7F]*$"
-      },
-      "connection": {
-         "type": "string",
-         "enum": [
-            "keep-alive",
-            "close"
-         ]
-      }
-   },
-   "required": [
-      "content-type",
-      "x-attestation-token"
-   ],
-   "additionalProperties": false
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "content-type": {
+            "type": "string",
+            "enum": [
+                "application/x-www-form-urlencoded",
+                "application/x-www-form-urlencoded; charset=UTF-8",
+                "application/json",
+                "application/json; charset=UTF-8",
+                "application/jwt",
+                "multipart/form-data"
+            ]
+        },
+        "x-attestation-token": {
+            "type": "string",
+            "pattern": "^[\\x00-\\x7F]*$"
+        },
+        "accept": {
+            "description": "Client's preferred response format from Cognito.",
+            "type": "string",
+            "maxLength": 1024,
+            "pattern": "^[\\x00-\\x7F]*$"
+        },
+        "user-agent": {
+            "description": "Identifies the client or proxy software making the request.",
+            "type": "string",
+            "maxLength": 1024,
+            "pattern": "^[\\x00-\\x7F]*$"
+        },
+        "connection": {
+            "type": "string",
+            "enum": [
+                "keep-alive",
+                "close"
+            ]
+        }
+    },
+    "required": [
+        "content-type",
+        "x-attestation-token"
+    ],
+    "additionalProperties": false
 }

--- a/auth/proxy/header-schema.json
+++ b/auth/proxy/header-schema.json
@@ -1,38 +1,41 @@
 {
-   "$schema":"https://json-schema.org/draft/2020-12/schema",
-   "type":"object",
-   "properties":{
-      "content-type":{
-         "type":"string",
-         "const":"application/x-www-form-urlencoded"
+   "$schema": "https://json-schema.org/draft/2020-12/schema",
+   "type": "object",
+   "properties": {
+      "content-type": {
+         "type": "string",
+         "enum": [
+            "application/x-www-form-urlencoded",
+            "application/json"
+         ]
       },
-      "x-attestation-token":{
-         "type":"string",
-         "pattern":"^[\\x00-\\x7F]*$"
+      "x-attestation-token": {
+         "type": "string",
+         "pattern": "^[\\x00-\\x7F]*$"
       },
-      "accept":{
-         "description":"Client's preferred response format from Cognito.",
-         "type":"string",
-         "maxLength":1024,
-         "pattern":"^[\\x00-\\x7F]*$"
+      "accept": {
+         "description": "Client's preferred response format from Cognito.",
+         "type": "string",
+         "maxLength": 1024,
+         "pattern": "^[\\x00-\\x7F]*$"
       },
-      "user-agent":{
-         "description":"Identifies the client or proxy software making the request.",
-         "type":"string",
-         "maxLength":1024,
-         "pattern":"^[\\x00-\\x7F]*$"
+      "user-agent": {
+         "description": "Identifies the client or proxy software making the request.",
+         "type": "string",
+         "maxLength": 1024,
+         "pattern": "^[\\x00-\\x7F]*$"
       },
-      "connection":{
-         "type":"string",
-         "enum":[
+      "connection": {
+         "type": "string",
+         "enum": [
             "keep-alive",
             "close"
          ]
       }
    },
-   "required":[
+   "required": [
       "content-type",
       "x-attestation-token"
    ],
-   "additionalProperties":false
+   "additionalProperties": false
 }

--- a/auth/proxy/sanitize-headers.ts
+++ b/auth/proxy/sanitize-headers.ts
@@ -8,7 +8,7 @@ const maxHeaderValueLength = 1024; // adjust as appropriate
 // eslint-disable-next-line no-control-regex, sonarjs/no-control-regex
 const asciiString = z.string().regex(/^[\x00-\x7F]*$/, { message: "Non-ASCII character found" });
 
-export const headerSchema = z.object({
+const headerSchema = z.object({
     'content-type': z.enum([
         "application/x-www-form-urlencoded",
         "application/json"
@@ -29,7 +29,7 @@ export const headerSchema = z.object({
             'close' // close connection after request
         ])
         .optional()
-})
+}) // by default, any unrecognized keys in the input object will be automatically stripped from the parsed result
 
 export type SanitizedRequestHeaders = z.infer<typeof headerSchema>;
 

--- a/auth/proxy/sanitize-headers.ts
+++ b/auth/proxy/sanitize-headers.ts
@@ -11,7 +11,11 @@ const asciiString = z.string().regex(/^[\x00-\x7F]*$/, { message: "Non-ASCII cha
 const headerSchema = z.object({
     'content-type': z.enum([
         "application/x-www-form-urlencoded",
-        "application/json"
+        "application/x-www-form-urlencoded; charset=UTF-8",
+        "application/json",
+        "application/json; charset=UTF-8",
+        "application/jwt", // sometimes used for JWT assertions
+        "multipart/form-data" // rarely, but possible for some extensions
     ]),
     'x-attestation-token': asciiString, 
     'accept': asciiString

--- a/auth/proxy/sanitize-headers.ts
+++ b/auth/proxy/sanitize-headers.ts
@@ -1,5 +1,3 @@
-
-
 import type { APIGatewayProxyEventHeaders } from "aws-lambda";
 import { z } from "zod/v4";
 
@@ -14,8 +12,6 @@ const headerSchema = z.object({
         "application/x-www-form-urlencoded; charset=UTF-8",
         "application/json",
         "application/json; charset=UTF-8",
-        "application/jwt", // sometimes used for JWT assertions
-        "multipart/form-data" // rarely, but possible for some extensions
     ]),
     'x-attestation-token': asciiString, 
     'accept': asciiString

--- a/auth/proxy/sanitize-headers.ts
+++ b/auth/proxy/sanitize-headers.ts
@@ -8,8 +8,11 @@ const maxHeaderValueLength = 1024; // adjust as appropriate
 // eslint-disable-next-line no-control-regex, sonarjs/no-control-regex
 const asciiString = z.string().regex(/^[\x00-\x7F]*$/, { message: "Non-ASCII character found" });
 
-const headerSchema = z.object({
-    'content-type': z.literal("application/x-www-form-urlencoded"),
+export const headerSchema = z.object({
+    'content-type': z.enum([
+        "application/x-www-form-urlencoded",
+        "application/json"
+    ]),
     'x-attestation-token': asciiString, 
     'accept': asciiString
         .max(maxHeaderValueLength)
@@ -26,7 +29,7 @@ const headerSchema = z.object({
             'close' // close connection after request
         ])
         .optional()
-}) // by default, any unrecognized keys in the input object will be automatically stripped from the parsed result
+})
 
 export type SanitizedRequestHeaders = z.infer<typeof headerSchema>;
 

--- a/auth/proxy/tests/unit/handler.unit.test.ts
+++ b/auth/proxy/tests/unit/handler.unit.test.ts
@@ -218,7 +218,7 @@ describe('lambdaHandler', () => {
         [
             {
                 'x-attestation-token': 'valid',
-                'content-type': 'application/json'
+                'content-type': 'text/javascript;'
             },
             {
                 status: 400,

--- a/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
+++ b/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { headerSchema, sanitizeHeaders } from '../../sanitize-headers';
-import { z, ZodError } from 'zod/v4';
+import { sanitizeHeaders } from '../../sanitize-headers';
+import { ZodError } from 'zod/v4';
 
 describe('sanitizeHeaders', () => {
     const validHeaders = {

--- a/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
+++ b/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeHeaders } from '../../sanitize-headers';
-import { ZodError } from 'zod/v4';
+import { headerSchema, sanitizeHeaders } from '../../sanitize-headers';
+import { z, ZodError } from 'zod/v4';
 
 describe('sanitizeHeaders', () => {
     const validHeaders = {
@@ -30,6 +30,17 @@ describe('sanitizeHeaders', () => {
             .resolves
             .toEqual(validHeaders) // An empty object, as all these headers should be stripped.
     });
+
+    it.each([
+        'application/json',
+        'application/x-www-form-urlencoded'
+    ])('should allow specific content-type headers', async (contentType) => {
+        await expect(sanitizeHeaders({
+            ...validHeaders,
+            'Content-Type': contentType,
+        }))
+            .resolves
+    })
 
     it('should allow whitelisted headers', async () => {
         const headers = {

--- a/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
+++ b/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
@@ -33,7 +33,8 @@ describe('sanitizeHeaders', () => {
 
     it.each([
         'application/json',
-        'application/x-www-form-urlencoded'
+        'application/x-www-form-urlencoded',
+        "application/x-www-form-urlencoded; charset=UTF-8"
     ])('should allow specific content-type headers', async (contentType) => {
         await expect(sanitizeHeaders({
             ...validHeaders,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1122,8 +1122,6 @@
     },
     "auth/node_modules/@types/node": {
       "version": "20.17.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
-      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1244,6 +1242,20 @@
       "version": "4.1.1",
       "license": "MIT"
     },
+    "auth/node_modules/prettier": {
+      "version": "3.5.3",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "auth/node_modules/strnum": {
       "version": "1.1.2",
       "funding": [
@@ -1252,6 +1264,11 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT"
+    },
+    "auth/node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
       "license": "MIT"
     },
     "auth/node_modules/uuid": {
@@ -1503,6 +1520,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -1584,6 +1612,17 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
@@ -3217,17 +3256,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
@@ -4151,6 +4179,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -4179,14 +4218,14 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -6800,9 +6839,9 @@
       ]
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.2.0.tgz",
-      "integrity": "sha512-eSPLTxVPFMdDE0vuiuCxckob4RJEMM/AO8Z86X3WCZ1V6b9SuMeCaxR6Ebbl/fy2QO+IXWOwtGrvcWY/nSG2dw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.2.1.tgz",
+      "integrity": "sha512-GLNByl+nFP1GPAhmlL7iFVonVKk/GuZcCfNSXX6uPuH30X62jmQy3ZkzxTZoHLkTQwTONM/JY9sxVjQyuL6koQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6821,19 +6860,19 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.0"
+        "vitest": "3.2.1"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
-      "integrity": "sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.1.tgz",
+      "integrity": "sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.0",
-        "@vitest/utils": "3.2.0",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -6842,13 +6881,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.0.tgz",
-      "integrity": "sha512-HFcW0lAMx3eN9vQqis63H0Pscv0QcVMo1Kv8BNysZbxcmHu3ZUYv59DS6BGYiGQ8F5lUkmsfMMlPm4DJFJdf/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.1.tgz",
+      "integrity": "sha512-OXxMJnx1lkB+Vl65Re5BrsZEHc90s5NMjD23ZQ9NlU7f7nZiETGoX4NeKZSmsKjseuMq2uOYXdLOeoM0pJU+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.0",
+        "@vitest/spy": "3.2.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -6869,9 +6908,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
-      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.1.tgz",
+      "integrity": "sha512-xBh1X2GPlOGBupp6E1RcUQWIxw0w/hRLd3XyBS6H+dMdKTAqHDNsIR2AnJwPA3yYe9DFy3VUKTe3VRTrAiQ01g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6882,13 +6921,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.0.tgz",
-      "integrity": "sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.1.tgz",
+      "integrity": "sha512-kygXhNTu/wkMYbwYpS3z/9tBe0O8qpdBuC3dD/AW9sWa0LE/DAZEjnHtWA9sIad7lpD4nFW1yQ+zN7mEKNH3yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.0",
+        "@vitest/utils": "3.2.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -6896,13 +6935,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.0.tgz",
-      "integrity": "sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.1.tgz",
+      "integrity": "sha512-5xko/ZpW2Yc65NVK9Gpfg2y4BFvcF+At7yRT5AHUpTg9JvZ4xZoyuRY4ASlmNcBZjMslV08VRLDrBOmUe2YX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.0",
+        "@vitest/pretty-format": "3.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -6911,9 +6950,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.0.tgz",
-      "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.1.tgz",
+      "integrity": "sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6924,13 +6963,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
-      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.1.tgz",
+      "integrity": "sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.0",
+        "@vitest/pretty-format": "3.2.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -10730,6 +10769,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/istanbul-lib-source-maps/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/istanbul-reports": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
@@ -13418,13 +13468,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -13682,9 +13725,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.0.tgz",
-      "integrity": "sha512-8Fc5Ko5Y4URIJkmMF/iFP1C0/OJyY+VGVe9Nw6WAdZyw4bTO+eVg9mwxWkQp/y8NnAoQY3o9KAvE1ZdA2v+Vmg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
+      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13764,20 +13807,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.0.tgz",
-      "integrity": "sha512-P7Nvwuli8WBNmeMHHek7PnGW4oAZl9za1fddfRVidZar8wDZRi7hpznLKQePQ8JPLwSBEYDK11g+++j7uFJV8Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.1.tgz",
+      "integrity": "sha512-VZ40MBnlE1/V5uTgdqY3DmjUgZtIzsYq758JGlyQrv5syIsaYcabkfPkEuWML49Ph0D/SoqpVFd0dyVTr551oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.0",
-        "@vitest/mocker": "3.2.0",
-        "@vitest/pretty-format": "^3.2.0",
-        "@vitest/runner": "3.2.0",
-        "@vitest/snapshot": "3.2.0",
-        "@vitest/spy": "3.2.0",
-        "@vitest/utils": "3.2.0",
+        "@vitest/expect": "3.2.1",
+        "@vitest/mocker": "3.2.1",
+        "@vitest/pretty-format": "^3.2.1",
+        "@vitest/runner": "3.2.1",
+        "@vitest/snapshot": "3.2.1",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -13791,7 +13834,7 @@
         "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.0",
+        "vite-node": "3.2.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -13807,8 +13850,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.0",
-        "@vitest/ui": "3.2.0",
+        "@vitest/browser": "3.2.1",
+        "@vitest/ui": "3.2.1",
         "happy-dom": "*",
         "jsdom": "*"
       },


### PR DESCRIPTION
Here’s a concise code review for the provided diff from [alphagov/govuk-mobile-backend PR #138](https://github.com/alphagov/govuk-mobile-backend/pull/138):

---

## Summary

This PR expands the allowed values for the `content-type` header in the authentication proxy, updates the header schema/validation, and adds/adjusts unit tests to match these changes.

---

### **Expanded Allowed Content-Types**

**Change**:
- The strict `"application/x-www-form-urlencoded"` literal for `content-type` was replaced by an enum allowing:
  - `"application/x-www-form-urlencoded"`
  - `"application/x-www-form-urlencoded; charset=UTF-8"` required by iOS
  - `"application/json"`
  - `"application/json; charset=UTF-8"`

---

### **JSON Schema**

**Change**:
- The `"content-type"` property now uses an `"enum"` instead of a `"const"`.
