### PR TITLE
Feat/remove un-forwarded headers

### DIFF
--- a/auth/proxy/header-schema.json
+++ b/auth/proxy/header-schema.json
@@ -8,9 +8,7 @@
                 "application/x-www-form-urlencoded",
                 "application/x-www-form-urlencoded; charset=UTF-8",
                 "application/json",
-                "application/json; charset=UTF-8",
-                "application/jwt",
-                "multipart/form-data"
+                "application/json; charset=UTF-8"
             ]
         },
         "x-attestation-token": {
@@ -22,19 +20,6 @@
             "type": "string",
             "maxLength": 1024,
             "pattern": "^[\\x00-\\x7F]*$"
-        },
-        "user-agent": {
-            "description": "Identifies the client or proxy software making the request.",
-            "type": "string",
-            "maxLength": 1024,
-            "pattern": "^[\\x00-\\x7F]*$"
-        },
-        "connection": {
-            "type": "string",
-            "enum": [
-                "keep-alive",
-                "close"
-            ]
         }
     },
     "required": [

--- a/auth/proxy/sanitize-headers.ts
+++ b/auth/proxy/sanitize-headers.ts
@@ -18,17 +18,6 @@ const headerSchema = z.object({
         .max(maxHeaderValueLength)
         .optional()
         .describe("Client's preferred response format from Cognito."),
-    'user-agent': asciiString
-        .max(maxHeaderValueLength)
-        .optional()
-        .describe("Identifies the client or proxy software making the request."),
-    // 'host': asciiString.optional(),
-    'connection': z
-        .enum([
-            'keep-alive', // for persistent connections
-            'close' // close connection after request
-        ])
-        .optional()
 }) // by default, any unrecognized keys in the input object will be automatically stripped from the parsed result
 
 export type SanitizedRequestHeaders = z.infer<typeof headerSchema>;

--- a/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
+++ b/auth/proxy/tests/unit/sanitize-headers.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { sanitizeHeaders } from '../../sanitize-headers';
-import { ZodError } from 'zod/v4';
+import { ZodError, z } from 'zod/v4';
 
 describe('sanitizeHeaders', () => {
     const validHeaders = {
@@ -43,12 +43,20 @@ describe('sanitizeHeaders', () => {
             .resolves
     })
 
+    it('should check content length of accept', async (header) => {
+        const longString = 'a'.repeat(1025)
+        await expect(sanitizeHeaders({
+            ...validHeaders,
+            accept: longString,
+        }))
+            .rejects
+            .toThrow(ZodError)
+    })
+
     it('should allow whitelisted headers', async () => {
         const headers = {
             ...validHeaders,
             'accept': 'application/json',
-            'user-agent': 'mozilla',
-            'connection': 'keep-alive'
         };
         const sanitized = await sanitizeHeaders(headers);
         expect(sanitized).toEqual(headers);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,20 +1242,6 @@
       "version": "4.1.1",
       "license": "MIT"
     },
-    "auth/node_modules/prettier": {
-      "version": "3.5.3",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "auth/node_modules/strnum": {
       "version": "1.1.2",
       "funding": [


### PR DESCRIPTION
---

## Summary

This PR removes support for the headers `user-agent` and `connection` in the header validation schema and sanitization logic. It also updates tests to reflect these changes and adds a new test for maximum header value length on accept.

* `user-agent` can be used for observability but doesn't need to be forwarded to cognito
* `connection` should be set by forwarding proxy not the client
* `content-length` is automatically set by `https.request` and is more secure as the forwarding proxy sets the value [docs](https://nodejs.org/api/http.html#httprequestoptions-callback:~:text=If%20no%20Content%2DLength%20is%20set%2C%20data%20will%20automatically%20be%20encoded%20in%20HTTP%20Chunked%20transfer%20encoding%2C%20so%20that%20server%20knows%20when%20the%20data%20ends)
