### PR TITLE
Feat/add request body validation

### DIFF
--- a/auth/package.json
+++ b/auth/package.json
@@ -42,5 +42,4 @@
         "test:integration": "vitest run --project integration",
         "test:functional": "vitest run --project functional"
     }
-    
 }

--- a/auth/proxy/body-schema.json
+++ b/auth/proxy/body-schema.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "anyOf": [
+        {
+            "type": "object",
+            "properties": {
+                "grant_type": {
+                    "description": "Must be \"authorization_code\" for this grant type",
+                    "type": "string",
+                    "const": "authorization_code"
+                },
+                "client_id": {
+                    "description": "The client identifier issued to the client during the registration process",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                },
+                "redirect_uri": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000
+                },
+                "code": {
+                    "description": "The authorization code received from the authorization server",
+                    "type": "string",
+                    "minLength": 8,
+                    "maxLength": 512
+                },
+                "code_verifier": {
+                    "description": "The PKCE code verifier used to obtain the authorization code",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128
+                },
+                "scope": {
+                    "description": "The scope of the access request, as a space-delimited string",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                }
+            },
+            "required": [
+                "grant_type",
+                "client_id",
+                "redirect_uri",
+                "code",
+                "code_verifier",
+                "scope"
+            ],
+            "additionalProperties": false
+        },
+        {
+            "type": "object",
+            "properties": {
+                "grant_type": {
+                    "type": "string",
+                    "const": "refresh_token"
+                },
+                "refresh_token": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "client_id": {
+                    "description": "The client identifier issued to the client during the registration process",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 100
+                }
+            },
+            "required": [
+                "grant_type",
+                "refresh_token",
+                "client_id"
+            ],
+            "additionalProperties": false
+        }
+    ]
+}

--- a/auth/proxy/tests/unit/validation/body.unit.test.ts
+++ b/auth/proxy/tests/unit/validation/body.unit.test.ts
@@ -1,0 +1,233 @@
+import { describe } from "node:test";
+import querystring from 'querystring';
+import { expect, it } from "vitest";
+import { RequestBody, validateRequestBodyOrThrow } from "../../../validation/body"
+import { ZodError } from "zod/v4";
+
+describe('validation', () => {
+    const getValidAuthorizationGrantBody = (overrides?: any): RequestBody => ({
+        grant_type: "authorization_code",
+        client_id: "1aaa111aaa1aaaaaa1111aaaaa",
+        redirect_uri: "govuk://govuk/login-auth-callback",
+        code: "2b57eu0w-3333-1111-992d-a623afdd7b73",
+        code_verifier: "1AAaA1AaAAAAaaAAA1aAaA1AaAaaaa1AaaAAaAaa1Aa", // pragma: allowlist-secret
+        scope: "openid email",
+        ...overrides
+    })
+
+    const getValidRefreshGrantBody = (overrides?: any): RequestBody => ({
+        grant_type: "refresh_token",
+        client_id: "1aaa111aaa1aaaaaa1111aaaaa",
+        refresh_token: 'eyJjdH',
+        ...overrides
+    })
+
+    it.each([
+        getValidAuthorizationGrantBody(),
+        getValidRefreshGrantBody(),
+    ])
+        ('should perform validation based on the grant type in the request', async (body) => {
+            await expect(validateRequestBodyOrThrow(querystring.stringify(body)))
+                .resolves
+                .toEqual(body)
+        })
+
+    it.each([
+        undefined,
+        null,
+        ""
+    ])
+        ('should throw an error if body is missing', async (body) => {
+            await expect(validateRequestBodyOrThrow(body))
+                .rejects
+                .toThrowError(expect.objectContaining({
+                    name: 'ZodError',
+                    message: expect.stringContaining("Invalid input: body is undefined")
+                }))
+        })
+
+    it.each([
+        getValidAuthorizationGrantBody({
+            malicious_content: 'foobar'
+        }),
+        getValidRefreshGrantBody({
+            malicious_content: 'foobar'
+        }),
+    ])('should ignore extra fields', async (body) => {
+        const result = await validateRequestBodyOrThrow(querystring.stringify(body));
+        expect(result).not.toHaveProperty('malicious_content');
+    })
+
+    it.each([
+        ["implicit", getValidAuthorizationGrantBody()],
+        ["client_credentials", getValidAuthorizationGrantBody()],
+        [null, getValidAuthorizationGrantBody()],
+        [undefined, getValidAuthorizationGrantBody()],
+        ["", getValidAuthorizationGrantBody()],
+        // refresh
+        ["implicit", getValidRefreshGrantBody()],
+        ["client_credentials", getValidRefreshGrantBody()],
+        [null, getValidRefreshGrantBody()],
+        [undefined, getValidRefreshGrantBody()],
+        ["", getValidRefreshGrantBody()],
+    ])
+        ('should throw an error if grant type is not known grant type', async (grantType, body) => {
+            await expect(validateRequestBodyOrThrow(querystring.stringify({
+                ...body,
+                grant_type: grantType
+            })))
+                .rejects
+                .toThrowError(ZodError)
+        })
+
+    it('should throw an exception if body is not valid query string', async () => {
+        // Not a query string: object
+        await expect(validateRequestBodyOrThrow({ foo: "bar" } as any))
+            .rejects
+            .toThrowError(ZodError);
+
+        // Not a query string: array
+        await expect(validateRequestBodyOrThrow(["foo=bar"] as any))
+            .rejects
+            .toThrowError(ZodError);
+
+        // Not a query string: malformed string
+        await expect(validateRequestBodyOrThrow("not-a-query-string"))
+            .rejects
+            .toThrowError(ZodError);
+
+        // Not a query string: random string
+        await expect(validateRequestBodyOrThrow("foo=bar&baz"))
+            .rejects
+            .toThrowError(ZodError);
+    })
+
+    describe('authorization grant type', () => {
+        it('should allow valid body', async () => {
+            const stringifiedBody = querystring.stringify(getValidAuthorizationGrantBody())
+            await expect(validateRequestBodyOrThrow(stringifiedBody))
+                .resolves
+                .toEqual(querystring.parse(stringifiedBody))
+        })
+
+        it.each([
+            "grant_type",
+            "client_id",
+            "redirect_uri",
+            "code",
+            "scope",
+        ])
+            ('should throw an error if required field %s is missing', async (field) => {
+                const bodyCopy = {
+                    ...getValidAuthorizationGrantBody()
+                }
+                delete bodyCopy[field]
+
+                await expect(validateRequestBodyOrThrow(querystring.stringify(bodyCopy)))
+                    .rejects
+                    .toThrow(ZodError)
+            })
+
+        it.each([
+            "",
+            "a".repeat(101),
+        ])
+            ('should throw an error if client id is wrong length', async (clientId) => {
+                await expect(validateRequestBodyOrThrow(querystring.stringify(
+                    getValidAuthorizationGrantBody({
+                        client_id: clientId
+                    })
+                )))
+                    .rejects
+                    .toThrowError(ZodError)
+            })
+
+        it.each([
+            "",
+            "a".repeat(2001),
+        ])('should throw an error if redirect_uri is too long', async (redirectUri) => {
+            await expect(validateRequestBodyOrThrow(querystring.stringify(
+                getValidAuthorizationGrantBody({
+                    redirect_uri: redirectUri
+                })
+            )))
+                .rejects
+                .toThrow(ZodError)
+        })
+
+        it.each([
+            "a",
+            "a".repeat(513),
+        ])
+            ('should throw an error if authorization code is wrong length', async (code) => {
+                await expect(validateRequestBodyOrThrow(querystring.stringify(
+                    getValidAuthorizationGrantBody({
+                        code
+                    })
+                )))
+                    .rejects
+                    .toThrow(ZodError)
+            })
+
+        it.each([
+            "",
+            "a".repeat(129),
+        ])
+            ('should throw an error if code verifier is wrong length', async (codeVerifier) => {
+                await expect(validateRequestBodyOrThrow(querystring.stringify(
+                    getValidAuthorizationGrantBody({
+                        code_verifier: codeVerifier
+                    })
+                )))
+                    .rejects
+                    .toThrow(ZodError)
+            })
+    })
+
+    describe('refresh token grant type', () => {
+        it('should allow valid body', async () => {
+            const stringifiedBody = querystring.stringify(getValidRefreshGrantBody())
+            await expect(validateRequestBodyOrThrow(stringifiedBody))
+                .resolves
+                .toEqual(querystring.parse(stringifiedBody))
+        })
+
+        it.each([
+            "grant_type",
+            "client_id",
+            "refresh_token",
+        ])
+            ('should throw an error if required field %s is missing', async (field) => {
+                const bodyCopy = {
+                    ...getValidRefreshGrantBody()
+                }
+                delete bodyCopy[field]
+
+                await expect(validateRequestBodyOrThrow(querystring.stringify(bodyCopy)))
+                    .rejects
+                    .toThrow(ZodError)
+            })
+
+        it.each([
+            "",
+            "a".repeat(101),
+        ])
+            ('should throw an error if client id is wrong length', async (clientId) => {
+                await expect(validateRequestBodyOrThrow(querystring.stringify(getValidRefreshGrantBody({
+                    client_id: clientId
+                }))))
+                    .rejects
+                    .toThrowError(ZodError)
+            })
+
+        it('should throw an error if refresh_token is too short', async () => {
+            await expect(validateRequestBodyOrThrow(querystring.stringify(getValidRefreshGrantBody({
+                refresh_token: ""
+            }))))
+                .rejects
+                .toThrow(ZodError)
+        })
+    })
+
+
+})

--- a/auth/proxy/validation/body.ts
+++ b/auth/proxy/validation/body.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { z, ZodError } from "zod/v4";
+import querystring from 'querystring';
+
+const clientId = z.string()
+        .min(1, { message: 'client_id is required' })
+        .max(100, { message: 'client_id is too long' })
+        .describe('The client identifier issued to the client during the registration process')
+
+const authorizationCodeSchema = z.object({
+    grant_type: z.literal('authorization_code')
+        .describe('Must be "authorization_code" for this grant type'),
+    client_id: clientId,
+    redirect_uri: z.string()
+        .min(1)
+        .max(2000, { message: 'redirect_uri is too long' }),
+    code: z.string()
+        .min(8, { message: 'code is required and must be at least 8 characters' })
+        .max(512, { message: 'code is too long' })
+        .describe('The authorization code received from the authorization server'),
+    code_verifier: z.string()
+        .min(1)
+        .max(128, { message: 'code_verifier must be at most 128 characters' })
+        .describe('The PKCE code verifier used to obtain the authorization code'),
+    scope: z.string()
+        .min(1, { message: 'scope is required' })
+        .max(1000, { message: 'scope is too long' })
+        .describe('The scope of the access request, as a space-delimited string'),
+});
+
+// Define the schema for 'refresh_token' grant type
+const refreshTokenSchema = z.object({
+  grant_type: z.literal('refresh_token'),
+  refresh_token: z.string().min(1, 'Refresh token is required'),
+  client_id: clientId,
+});
+
+const grantUnionSchema = z.discriminatedUnion('grant_type', [
+  authorizationCodeSchema,
+  refreshTokenSchema,
+]);
+
+export type RequestBody = z.infer<typeof grantUnionSchema>;
+
+export const validateRequestBodyOrThrow = async (body: unknown): Promise<RequestBody> => {
+    if (body == null || body === '' || typeof body !== 'string') {
+      throw new ZodError([
+        {
+            code: 'invalid_value',
+            values: [
+                "body"
+            ],
+            path: [
+                "body"
+            ],
+            "message": "Invalid input: body is undefined",
+            input: body
+        }
+      ])
+    }
+
+    const parsedBody = querystring.parse(body);
+    return grantUnionSchema.parseAsync(parsedBody)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1242,20 +1242,6 @@
       "version": "4.1.1",
       "license": "MIT"
     },
-    "auth/node_modules/prettier": {
-      "version": "3.5.3",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "auth/node_modules/strnum": {
       "version": "1.1.2",
       "funding": [


### PR DESCRIPTION
## Description

* `grant_type` can only be `authorization_code`
* `client_id` assert is a string of relevant length. For increased validation, this has been separated out as future work - we can pull this from SSM or resolve in SAM
* `redirect_uri` assert is a string of relevant length. For increased validation, we can check if redirect uri points to mobile app, however for testing we (using values like localhost) we need to be able to change this based on environment. Separated out as future work.
* `scope` assert is a string of relevant length. Can be updated to be a literal value we expect, however this tightly couples the validation to that configuration.

### Ticket number

[GOVUKAPP-1796
](https://govukverify.atlassian.net/jira/software/c/projects/GOVUKAPP/boards/832?selectedIssue=GOVUKAPP-1796)
