### PR TITLE
feat: Implement permission boundary for post-authentication Lambda function

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -873,8 +873,10 @@ Resources:
   PostAuthenticationFunction:
     Type: AWS::Serverless::Function
     Properties:
+      FunctionName: !Sub "${AWS::StackName}-post-authentication-function"
       CodeUri: post-authentication-function/
       Handler: app.lambdaHandler
+      Role: !GetAtt PostAuthenticationFunctionIAMRole.Arn
       Tags:
         Product: GOV.UK
         Environment: !Ref Environment
@@ -887,6 +889,52 @@ Resources:
         SourceMap: false
         EntryPoints:
           - app.ts
+
+  PostAuthenticationFunctionIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join
+        - "-"
+        - - !Ref AWS::StackName
+          - "post-authentication-role"
+          - Fn::Select:
+              - 4
+              - Fn::Split:
+                  - "-"
+                  - Fn::Select:
+                      - 2
+                      - Fn::Split:
+                          - "/"
+                          - Ref: AWS::StackId
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: PostAuthenticationFunctionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-post-authentication-function:*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
 
   UserPoolIdentityProvider:
     Type: AWS::Cognito::UserPoolIdentityProvider
@@ -1028,10 +1076,10 @@ Resources:
           Value: Authentication
 
   AuthProxyWafAssociation:
-      Type: AWS::WAFv2::WebACLAssociation
-      Properties:
-        ResourceArn: !Sub "arn:${AWS::Partition}:apigateway:${AWS::Region}::/restapis/${AttestationProxyApi}/stages/${AttestationProxyApi.Stage}"
-        WebACLArn: !GetAtt AuthProxyWaf.Arn
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Sub "arn:${AWS::Partition}:apigateway:${AWS::Region}::/restapis/${AttestationProxyApi}/stages/${AttestationProxyApi.Stage}"
+      WebACLArn: !GetAtt AuthProxyWaf.Arn
 
   AttestationProxyApi:
     Type: AWS::Serverless::Api
@@ -1571,4 +1619,3 @@ Outputs:
   CognitoSecretName:
     Description: The name of the App Cognito User Pool Client Secret stored in Secrets manager.
     Value: !Sub /${ConfigStackName}/cognito/client-secret
-    

--- a/auth/tests/acc/cognito-throttles-cloudwatch-alarms.test.ts
+++ b/auth/tests/acc/cognito-throttles-cloudwatch-alarms.test.ts
@@ -25,7 +25,7 @@ type AlarmTestCase = {
 
 const testCases: AlarmTestCase[] = [
   {
-    alarmName: testConfig.CloudWatchAlarmFederationThrottlesName,
+    alarmName: testConfig.cloudWatchAlarmFederationThrottlesName,
     actionsEnabled: true,
     metricName: "FederationThrottles",
     alarmDescription: "Alarm when federated requests exceeds 5 per minute",
@@ -37,7 +37,7 @@ const testCases: AlarmTestCase[] = [
     ],
   },
   {
-    alarmName: testConfig.CloudWatchAlarmSignInThrottlesName,
+    alarmName: testConfig.cloudWatchAlarmSignInThrottlesName,
     actionsEnabled: true,
     metricName: "SignInThrottles",
     alarmDescription: "Alarm when the sign in rate exceeds 5 per minute",
@@ -48,7 +48,7 @@ const testCases: AlarmTestCase[] = [
     ],
   },
   {
-    alarmName: testConfig.CloudWatchAlarmSignUpThrottlesName,
+    alarmName: testConfig.cloudWatchAlarmSignUpThrottlesName,
     actionsEnabled: true,
     metricName: "SignUpThrottles",
     alarmDescription: "Alarm when the sign up rate exceeds 5 per minute",
@@ -59,7 +59,7 @@ const testCases: AlarmTestCase[] = [
     ],
   },
   {
-    alarmName: testConfig.CloudWatchAlarmTokenRefreshThrottlesName,
+    alarmName: testConfig.cloudWatchAlarmTokenRefreshThrottlesName,
     actionsEnabled: true,
     metricName: "TokenRefreshThrottles",
     alarmDescription: "Alarm when the token refresh rate exceeds 5 per minute",
@@ -171,14 +171,14 @@ describe.each(testCases)(
 
     const chatConfigurationResponse = await chatbotClient.send(
       new DescribeSlackChannelConfigurationsCommand({
-        ChatConfigurationArn: testConfig.ChatConfigurationArn,
+        ChatConfigurationArn: testConfig.chatConfigurationArn,
       })
     );
     const chatConfiguration =
       chatConfigurationResponse.SlackChannelConfigurations?.[0];
     if (!chatConfiguration) {
       throw new Error(
-        `No SlackChannelConfigurations found for ARN: ${testConfig.ChatConfigurationArn}`
+        `No SlackChannelConfigurations found for ARN: ${testConfig.chatConfigurationArn}`
       );
     }
 

--- a/auth/tests/common/config.ts
+++ b/auth/tests/common/config.ts
@@ -12,19 +12,22 @@ const getTestConfig = () => {
     "CFN_SharedSignalsReceiverLogGroupName",
     "CFN_SharedSignalsApiId",
     "CFN_PostAuthenticationFunctionInvokePermission",
-    "CFN_CloudWatchAlarmSignUpThrottlesName",
+    "CFN_CloudWatchAlarmSignUpThrottlesName", // pragma: allowlist-secret
     "CFN_CloudWatchAlarmSignInThrottlesName",
     "CFN_CloudWatchAlarmTokenRefreshThrottlesName",
     "CFN_CloudWatchAlarmFederationThrottlesName",
     "CFN_SlackSupportChannelConfigurationARN",
     "CFN_CognitoSecretName",
     "CFN_SharedSignalClientId",
-    "CFN_PostAuthenticationFunctionName"
+    "CFN_PostAuthenticationFunctionName",
+    "CFN_AWSAccountId",
   ];
 
   const missing = requiredVars.filter((v) => !process.env[v]);
   if (missing.length > 0) {
-    throw new Error(`Missing required environment variables: ${missing.join(", ")}`);
+    throw new Error(
+      `Missing required environment variables: ${missing.join(", ")}`
+    );
   }
 
   return {
@@ -39,19 +42,22 @@ const getTestConfig = () => {
       process.env.CFN_SharedSignalsReceiverLogGroupName!,
     sharedSignalsApiId: process.env.CFN_SharedSignalsApiId!,
     postAuthenticationLambda: process.env.CFN_PostAuthenticationFunctionName!,
-    PostAuthenticationFunctionInvokePermission:
+    postAuthenticationFunctionInvokePermission:
       process.env.CFN_PostAuthenticationFunctionInvokePermission!,
-    CloudWatchAlarmSignUpThrottlesName:
+    postAuthenticationFunctionIAMRoleName:
+      process.env.CFN_PostAuthenticationFunctionIAMRoleName!,
+    cloudWatchAlarmSignUpThrottlesName:
       process.env.CFN_CloudWatchAlarmSignUpThrottlesName!,
-    CloudWatchAlarmSignInThrottlesName:
+    cloudWatchAlarmSignInThrottlesName:
       process.env.CFN_CloudWatchAlarmSignInThrottlesName!,
-    CloudWatchAlarmTokenRefreshThrottlesName:
+    cloudWatchAlarmTokenRefreshThrottlesName:
       process.env.CFN_CloudWatchAlarmTokenRefreshThrottlesName!,
-    CloudWatchAlarmFederationThrottlesName:
+    cloudWatchAlarmFederationThrottlesName:
       process.env.CFN_CloudWatchAlarmFederationThrottlesName!,
-    ChatConfigurationArn: process.env.CFN_SlackSupportChannelConfigurationARN!,
+    chatConfigurationArn: process.env.CFN_SlackSupportChannelConfigurationARN!,
     cognitoSecretName: process.env.CFN_CognitoSecretName!,
     authProxyUrl: process.env.CFN_AuthProxyUrl!,
+    awsAccountId: process.env.CFN_AWSAccountId!,
   };
 };
 

--- a/auth/tests/int/cognito-throttles-cloudwatch-alarms.test.ts
+++ b/auth/tests/int/cognito-throttles-cloudwatch-alarms.test.ts
@@ -9,10 +9,10 @@ import { testConfig } from "../common/config";
 const cloudWatchClient = new CloudWatchClient({ region: "eu-west-2" });
 
 const alarmsToTest = [
-  testConfig.CloudWatchAlarmSignUpThrottlesName,
-  testConfig.CloudWatchAlarmSignInThrottlesName,
-  testConfig.CloudWatchAlarmTokenRefreshThrottlesName,
-  testConfig.CloudWatchAlarmFederationThrottlesName,
+  testConfig.cloudWatchAlarmSignUpThrottlesName,
+  testConfig.cloudWatchAlarmSignInThrottlesName,
+  testConfig.cloudWatchAlarmTokenRefreshThrottlesName,
+  testConfig.cloudWatchAlarmFederationThrottlesName,
 ];
 
 describe.each(alarmsToTest)("Cognito CloudWatch Alarm: %s", (alarmName) => {


### PR DESCRIPTION
## Description

Introduce a permissions boundary for the post-authentication Lambda function to enhance security and ensure proper IAM role management. Update related configurations and tests accordingly, including consistent casing `config.ts`

GOVUKAPP-1833