### PR TITLE
fix: revert account level data protection to waf log groups

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -80,11 +80,6 @@ Conditions:
       - !Ref Environment
       - "production"
 
-  IsAccountLevel:
-    Fn::Equals:
-      - !Ref AccountLevel
-      - "True"    
-
 Globals:
   Function:
     CodeSigningConfigArn: !If
@@ -100,51 +95,6 @@ Globals:
     Runtime: nodejs22.x
 
 Resources:
-  AccountLevelDataProtectionPolicy:
-    Condition: IsAccountLevel
-    Type: AWS::Logs::AccountPolicy
-    Properties:
-      PolicyName: "TokenRedactionPolicy"
-      PolicyDocument: '{
-          "Description": "Protect against JWT tokens exposure",
-          "Configuration": {
-            "CustomDataIdentifier": [
-              {
-                "Regex": "eyJ[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_.+/=]*",
-                "Name": "JWTTokens"
-              }
-            ]
-          },
-          "Version": "2021-06-01",
-          "Statement": [
-            {
-              "DataIdentifier": [
-                "JWTTokens"
-              ],
-              "Operation": {
-                "Audit": {
-                  "FindingsDestination": {}
-                }
-              },
-              "Sid": "audit-policy"
-            },
-            {
-              "DataIdentifier": [
-                "JWTTokens"
-              ],
-              "Operation": {
-                "Deidentify": {
-                  "MaskConfig": {}
-                }
-              },
-              "Sid": "redact-policy"
-            }
-          ],
-          "Name": "CloudWatchLogs-JWTToken-Protection"
-        }'
-      PolicyType: "DATA_PROTECTION_POLICY"
-      Scope: "ALL"
-
   CognitoUserPool:
     Type: AWS::Cognito::UserPool
     Properties:
@@ -372,16 +322,22 @@ Resources:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
         Version: "2021-06-01"
+        Configuration:
+          CustomDataIdentifier:
+          - Name: JWTTokens
+            Regex: e[yw][A-Za-z0-9-_]+\.(?:e[yw][A-Za-z0-9-_]+)?\.[A-Za-z0-9-_]{2,}(?:(?:\.[A-Za-z0-9-_]{2,}){2})?
         Statement:
           - Sid: audit-policy
             DataIdentifier:
               - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - JWTTokens
             Operation:
               Audit:
                 FindingsDestination: {}
           - Sid: redact-policy
             DataIdentifier:
               - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - JWTTokens
             Operation:
               Deidentify:
                 MaskConfig: {}
@@ -1117,6 +1073,27 @@ Resources:
       LogGroupName: !Sub "aws-waf-logs-attestation-${AWS::StackName}"
       KmsKeyId: !GetAtt AuthProxyWAFLogGroupKMSKey.Arn
       RetentionInDays: 30
+      DataProtectionPolicy:
+        Name: CloudWatchLogs-PersonalInformation-Protection
+        Description: Protect basic types of sensitive data
+        Version: "2021-06-01"
+        Configuration:
+          CustomDataIdentifier:
+          - Name: JWTTokens
+            Regex: e[yw][A-Za-z0-9-_]+\.(?:e[yw][A-Za-z0-9-_]+)?\.[A-Za-z0-9-_]{2,}(?:(?:\.[A-Za-z0-9-_]{2,}){2})?
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - JWTTokens
+            Operation:
+              Audit:
+                FindingsDestination: {}
+          - Sid: redact-policy
+            DataIdentifier:
+              - JWTTokens
+            Operation:
+              Deidentify:
+                MaskConfig: {}
       Tags:
         - Key: Product
           Value: GOV.UK

--- a/auth/tests/acc/attestation-waf-log-group.test.ts
+++ b/auth/tests/acc/attestation-waf-log-group.test.ts
@@ -21,8 +21,8 @@ describe("Check the deployed Attestation WAF log group", async () => {
   }
 
   it("has data protection", () => {
-    const expectedDataProtection = "ACCOUNT_DATA_PROTECTION";
-    assert.equal(logGroup.inheritedProperties?.includes(expectedDataProtection), true);
+    const expectedDataProtectionStatus = "ACTIVATED";
+    assert.equal(logGroup.dataProtectionStatus, expectedDataProtectionStatus );
   });
 
   it("has an associated KMS key", () => {

--- a/auth/tests/int/waf-log-data-protection.test.ts
+++ b/auth/tests/int/waf-log-data-protection.test.ts
@@ -5,7 +5,7 @@ import axios from "axios";
 import querystring from "querystring";
 import jsonwebtoken from "jsonwebtoken";
 
-describe('account-level data protection log policies', () => {
+describe('waf logging data protection policies', () => {
     const startTime = Date.now() - 1 * 60 * 1000;
     const loggingDriver = new LoggingDriver();
 
@@ -33,7 +33,6 @@ describe('account-level data protection log policies', () => {
         const unmaskedHeaders = {
             'X-Attestation-Token': fakeJwt,
             'Authorization': `Bearer ${fakeJwt}`,
-            'test': randomId
         }
 
         beforeAll(async () => {
@@ -44,15 +43,16 @@ describe('account-level data protection log policies', () => {
                     headers: {
                         ...unmaskedHeaders,
                         'Content-Type': 'application/x-www-form-urlencoded',
+                        'test': randomId
                     }
                 }
             ).catch(e => console.log("error expected"))
 
             const message = await loggingDriver.findLogMessageWithRetries({
                 logGroupName: testConfig.authProxyWafLogGroupName,
-                searchString: 'test',
+                searchString: randomId,
                 startTime,
-                delayMs: 1000
+                delayMs: 4000
             })
 
             logMessages = JSON.parse(message)
@@ -71,7 +71,7 @@ describe('account-level data protection log policies', () => {
                 Object.entries(unmaskedHeaders)
                     .forEach(([k, v]) => {
                         const header = logMessages.httpRequest.headers.find((h) => h.name === k)
-                        expect(v).not.equal(header.value)
+                        expect(v).not.toEqual(header.value)
                     })
             })
         })
@@ -102,7 +102,6 @@ describe('account-level data protection log policies', () => {
         const unmaskedHeaders = {
             // cognito waf logs are lowercased
             'authorization': `Bearer ${fakeJwt}`,
-            'test': randomId
         }
 
         beforeAll(async () => {
@@ -112,17 +111,16 @@ describe('account-level data protection log policies', () => {
                     headers: {
                         ...unmaskedHeaders,
                         'Content-Type': 'application/x-www-form-urlencoded',
+                        'test': randomId
                     }
                 }
-            ).catch(e => {
-                console.log("error expected")
-            })
+            ).catch(e => console.log("error expected"))
 
             const message = await loggingDriver.findLogMessageWithRetries({
                 logGroupName: testConfig.cognitoWafLogGroupName,
                 searchString: 'authorize',
                 startTime,
-                delayMs: 3000
+                delayMs: 4000
             })
 
             logMessages = JSON.parse(message)

--- a/auth/tests/unit/cognito-waf-log-group.unit.test.ts
+++ b/auth/tests/unit/cognito-waf-log-group.unit.test.ts
@@ -19,12 +19,14 @@ describe("Set up the Cognito WAF Log Group for GovUK app", () => {
             Sid: "audit-policy",
             DataIdentifier: [
               "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+              "JWTTokens",
             ],
           },
           {
             Sid: "redact-policy",
             DataIdentifier: [
               "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+              "JWTTokens",
             ],
           },
         ],


### PR DESCRIPTION
- [x] `acc` tests passing
- [x] `int` tests passing

Regex approach: [JWT](https://regex101.com/r/V99DS0/3)