### PR TITLE
chore: rename ss auth function

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -1794,7 +1794,7 @@ Resources:
     Condition: IsNotProduction
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub ${AWS::StackName}-shared-signal-authorizer
+      FunctionName: !Sub ${AWS::StackName}-shared-signal-authorizer-function
       CodeUri: shared-signal-authorizer/
       Handler: app.lambdaHandler
       Role: !GetAtt SharedSignalAuthorizerIAMRole.Arn

--- a/auth/tests/unit/lambda.unit.test.ts
+++ b/auth/tests/unit/lambda.unit.test.ts
@@ -33,7 +33,7 @@ const testCases: LambdaTestCase[] = [
   },
   {
     resourceName: 'SharedSignalAuthorizer',
-    functionName: 'shared-signal-authorizer',
+    functionName: 'shared-signal-authorizer-function',
     codeUri: 'shared-signal-authorizer/',
     handler: 'app.lambdaHandler',
     role: 'SharedSignalAuthorizerIAMRole',


### PR DESCRIPTION
## Description

Fix issue whereby resource name change was conflicting with the lambda shared-signal-authoriser due to it already existing in the stack.

### Ticket number

[GOVUKAPP-2248]


[GOVUKAPP-2248]: https://govukverify.atlassian.net/browse/GOVUKAPP-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ