### PR TITLE
fix: use a fake user id to avoid conflicting user creation when runni…

### DIFF
--- a/auth/tests/acc/shared-signals-receiver.test.ts
+++ b/auth/tests/acc/shared-signals-receiver.test.ts
@@ -83,12 +83,8 @@ describe('shared-signal-receiver', () => {
     });
 
     it('sends a email update signal with an unsupported change type and receives a 400 BAD REQUEST response', async () => {
-      const cognitoUserId =
-        await cognitoUserDriver.createCognitoUserAndReturnUserName(
-          passwordUpdateUserName,
-        );
       const response = await sharedSignalsDriver.sendEmailSignal({
-        userId: cognitoUserId,
+        userId: 'foo',
         accessToken,
         email: 'test@test.com',
         changeType: 'CREATE', // unsupported change type


### PR DESCRIPTION
…ng entire test suite
