### PR TITLE
chore: change name of pager duty topic to make it predictable/easily re-usable across other stacks

### DIFF
--- a/auth/template.yaml
+++ b/auth/template.yaml
@@ -711,19 +711,8 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       KmsMasterKeyId: !Ref CloudWatchAlarmNotificationTopicKey
-      DisplayName: !Join
-        - '-'
-        - - !Ref AWS::StackName
-          - cloudwatch-alarm-topic
-          - !Select
-            - 4
-            - !Split
-              - '-'
-              - !Select
-                - 2
-                - !Split
-                  - /
-                  - !Ref AWS::StackId
+      TopicName: !Sub '${AWS::StackName}-cloudwatch-alarm-topic'
+      DisplayName: !Sub '${AWS::StackName}-cloudwatch-alarm-topic'
       Tags:
         - Key: Product
           Value: GOV.UK

--- a/auth/tests/unit/attestation-cloudwatch-alarms.test.ts
+++ b/auth/tests/unit/attestation-cloudwatch-alarms.test.ts
@@ -264,31 +264,7 @@ describe.each(testCases)(
       expect(snsTopicUnderTest.Type).toEqual('AWS::SNS::Topic');
       expect(snsTopicUnderTest.Properties).toBeDefined();
       expect(snsTopicUnderTest.Properties.DisplayName).toEqual({
-        'Fn::Join': [
-          '-',
-          [
-            { Ref: 'AWS::StackName' },
-            topicDisplayName,
-            {
-              'Fn::Select': [
-                4,
-                {
-                  'Fn::Split': [
-                    '-',
-                    {
-                      'Fn::Select': [
-                        2,
-                        {
-                          'Fn::Split': ['/', { Ref: 'AWS::StackId' }],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        ],
+        'Fn::Sub': '${AWS::StackName}-cloudwatch-alarm-topic',
       });
       expect(snsTopicUnderTest.Properties.KmsMasterKeyId).toEqual({
         Ref: 'CloudWatchAlarmNotificationTopicKey',

--- a/auth/tests/unit/cognito-throttles-cloudwatch-alarms.test.ts
+++ b/auth/tests/unit/cognito-throttles-cloudwatch-alarms.test.ts
@@ -286,31 +286,7 @@ describe.each(testCases)(
       expect(snsTopicUnderTest.Type).toEqual('AWS::SNS::Topic');
       expect(snsTopicUnderTest.Properties).toBeDefined();
       expect(snsTopicUnderTest.Properties.DisplayName).toEqual({
-        'Fn::Join': [
-          '-',
-          [
-            { Ref: 'AWS::StackName' },
-            topicDisplayName,
-            {
-              'Fn::Select': [
-                4,
-                {
-                  'Fn::Split': [
-                    '-',
-                    {
-                      'Fn::Select': [
-                        2,
-                        {
-                          'Fn::Split': ['/', { Ref: 'AWS::StackId' }],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        ],
+        'Fn::Sub': '${AWS::StackName}-cloudwatch-alarm-topic',
       });
       expect(snsTopicUnderTest.Properties.KmsMasterKeyId).toEqual({
         Ref: 'CloudWatchAlarmNotificationTopicKey',

--- a/auth/tests/unit/waf-throttling-cloudwatch-alarms.test.ts
+++ b/auth/tests/unit/waf-throttling-cloudwatch-alarms.test.ts
@@ -242,31 +242,7 @@ describe.each(testCases)(
       expect(snsTopicUnderTest.Type).toEqual('AWS::SNS::Topic');
       expect(snsTopicUnderTest.Properties).toBeDefined();
       expect(snsTopicUnderTest.Properties.DisplayName).toEqual({
-        'Fn::Join': [
-          '-',
-          [
-            { Ref: 'AWS::StackName' },
-            topicDisplayName,
-            {
-              'Fn::Select': [
-                4,
-                {
-                  'Fn::Split': [
-                    '-',
-                    {
-                      'Fn::Select': [
-                        2,
-                        {
-                          'Fn::Split': ['/', { Ref: 'AWS::StackId' }],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        ],
+        'Fn::Sub': '${AWS::StackName}-cloudwatch-alarm-topic',
       });
       expect(snsTopicUnderTest.Properties.KmsMasterKeyId).toEqual({
         Ref: 'CloudWatchAlarmNotificationTopicKey',


### PR DESCRIPTION
## Description

This PR changes the name of the resource `CloudWatchAlarmTopicPagerDuty` so that we can easily reference it from other stacks for CloudWatch Alarm Actions

### Ticket number

[GOVUKAPP-2110]



[GOVUKAPP-2110]: https://govukverify.atlassian.net/browse/GOVUKAPP-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ