### PR TITLE
Fix: Commenting out chat triggers to allow auth build to fix

### DIFF
--- a/.github/workflows/chat-post-merge.yaml
+++ b/.github/workflows/chat-post-merge.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Deploy Chat SAM app
         uses: govuk-one-login/devplatform-upload-action@v3.9.4
         with:
-          artifact-bucket-name: ${{ vars.ARTIFACT_BUCKET_NAME }}
+          artifact-bucket-name: ${{ vars.CHAT_ARTIFACT_BUCKET_NAME }} # Need to configure git environment for the new buckets
           signing-profile-name: ${{ vars.SIGNING_PROFILE_NAME }}
           working-directory: ./chat/.aws-sam/build
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,11 +19,11 @@ jobs:
     with:
       environment: dev
 
-  deploy-to-dev-chat:
-    name: deploy-to-dev-chat
-    uses: ./.github/workflows/chat-post-merge.yaml
-    with:
-      environment: dev
+  # deploy-to-dev-chat:
+  #   name: deploy-to-dev-chat
+  #   uses: ./.github/workflows/chat-post-merge.yaml
+  #   with:
+  #     environment: dev
 
   deploy-to-build-auth:
     name: deploy-to-build-auth
@@ -32,9 +32,9 @@ jobs:
     with:
       environment: build
 
-  deploy-to-build-chat:
-    name: deploy-to-build-chat
-    uses: ./.github/workflows/chat-post-merge.yaml
-    if: ${{ github.head_ref || contains(fromJSON('["main", "production"]'), github.ref_name) }}
-    with:
-      environment: build
+  # deploy-to-build-chat:
+  #   name: deploy-to-build-chat
+  #   uses: ./.github/workflows/chat-post-merge.yaml
+  #   if: ${{ github.head_ref || contains(fromJSON('["main", "production"]'), github.ref_name) }}
+  #   with:
+  #     environment: build


### PR DESCRIPTION
Commenting out chat triggers to allow auth build to fix - will then fix github environment for chat pipeline to pull in correct bucket for artifact storing to not overwrite the auth stack.

## Description

### Ticket number

[GOVUKAPP-2156]

## Checklist

- [ ] Is my change backwards compatible? **_Please include evidence_**

- [ ] I have installed and run pre-commit following guidance in README.md

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
      **_Comment:_**

- [ ] Automated tests added
      **_Comment:_**

- [ ] Documentation added ([link]())
      **_Comment:_**

- [ ] Delete any new stacks created for this ticket
      **_Comment:_**

- [ ] Running SAM tests (If so, please ensure `[run-sam-tests]` is in your commit.)

### Co-authored by


[GOVUKAPP-2156]: https://govukverify.atlassian.net/browse/GOVUKAPP-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ