### PR TITLE
Adding root level eslint-formatter-junit dev dependency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,11 +19,11 @@ jobs:
     with:
       environment: dev
 
- # deploy-to-dev-chat:
- #   name: deploy-to-dev-chat
- #   uses: ./.github/workflows/chat-post-merge.yaml
- #   with:
- #     environment: dev
+  # deploy-to-dev-chat:
+  #   name: deploy-to-dev-chat
+  #   uses: ./.github/workflows/chat-post-merge.yaml
+  #   with:
+  #     environment: dev
 
   deploy-to-build-auth:
     name: deploy-to-build-auth
@@ -32,9 +32,9 @@ jobs:
     with:
       environment: build
 
- # deploy-to-build-chat:
- #   name: deploy-to-build-chat
- #   uses: ./.github/workflows/chat-post-merge.yaml
- #   if: ${{ github.head_ref || contains(fromJSON('["main", "production"]'), github.ref_name) }}
- #   with:
- #     environment: build
+  # deploy-to-build-chat:
+  #   name: deploy-to-build-chat
+  #   uses: ./.github/workflows/chat-post-merge.yaml
+  #   if: ${{ github.head_ref || contains(fromJSON('["main", "production"]'), github.ref_name) }}
+  #   with:
+  #     environment: build

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "axios-cookiejar-support": "^6.0.4",
         "cheerio": "^1.1.2",
         "dotenv": "^16.5.0",
+        "eslint-formatter-junit": "^8.40.0",
         "eslint-import-resolver-typescript": "^4.3.5",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsdoc": "^50.6.17",
@@ -11399,6 +11400,16 @@
         }
       }
     },
+    "node_modules/eslint-formatter-junit": {
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-junit/-/eslint-formatter-junit-8.40.0.tgz",
+      "integrity": "sha512-brB5r40UlMbd/BcmPIxUy/UA4GSGkuA1YRTDX4I5mEjra1asxmjUTWetf65JqVMo2kg96ZIZjRutktcHCIy+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/eslint-import-context": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -15560,6 +15571,7 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "axios-cookiejar-support": "^6.0.4",
     "cheerio": "^1.1.2",
     "dotenv": "^16.5.0",
+    "eslint-formatter-junit": "^8.40.0",
     "eslint-import-resolver-typescript": "^4.3.5",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsdoc": "^50.6.17",


### PR DESCRIPTION
Small dependency update to let the nx commands work with the recently added JUnit formatted linting outputs for better visibility in GitHub actions.

## Description

### Ticket number

[GOCUKAPP-1752]

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**

- [x] I have installed and run pre-commit following guidance in README.md

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
      **_Comment:_**

- [ ] Automated tests added
      **_Comment:_**

- [ ] Documentation added ([link]())
      **_Comment:_**

- [ ] Delete any new stacks created for this ticket
      **_Comment:_**

- [ ] Running SAM tests (If so, please ensure `[run-sam-tests]` is in your commit.)

### Co-authored by
