### PR TITLE
fix: Adjusting invalid-token 

### DIFF
--- a/chat/tests/acc/api-gateway.test.ts
+++ b/chat/tests/acc/api-gateway.test.ts
@@ -18,7 +18,7 @@ describe('api gateway', () => {
     expect(body.message).toBe('Unauthorized');
   });
 
-  it('should return a 401 when an invalid Authorization token is provided', async () => {
+  it('should return a 403 when an invalid Authorization token is provided', async () => {
     const response = await fetch(
       `${testConfig.chatApiGatewayUrl}/conversation`,
       {
@@ -30,9 +30,9 @@ describe('api gateway', () => {
       },
     );
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(403);
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(403);
     const body = await response.json();
     expect(body.message).toBe('Unauthorized');
   });


### PR DESCRIPTION
## Description

Setting invalid-token test to expect 403 to reflect how APIGateway & Request authorisers behave with explicity deny policies.

Documentation: 
- https://repost.aws/knowledge-center/api-gateway-403-error-lambda-authorizer
- https://repost.aws/knowledge-center/api-gateway-401-error-lambda-authorizer

Essentially - when an explicity deny policy is returned by the authoirser, the response is 403 Forbidden. When the authoriser is not invoked due to no required identity source present (when we don't provide any Authorization header) it will return 401 Unauthorized. This is just how AWS works.

### Ticket number

Not really ticketed.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**

- [x] I have installed and run pre-commit following guidance in README.md

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
      **_Comment:_**

- [ ] Automated tests added
      **_Comment:_**

- [ ] Documentation added ([link]())
      **_Comment:_**

- [ ] Delete any new stacks created for this ticket
      **_Comment:_**

- [ ] Running SAM tests (If so, please ensure `[run-sam-tests]` is in your commit.)

### Co-authored by
