### PR TITLE
fix: removed body expectation on 403 error

### DIFF
--- a/chat/tests/acc/api-gateway.test.ts
+++ b/chat/tests/acc/api-gateway.test.ts
@@ -31,9 +31,5 @@ describe('api gateway', () => {
     );
 
     expect(response.status).toBe(403);
-
-    expect(response.status).toBe(403);
-    const body = await response.json();
-    expect(body.message).toBe('Unauthorized');
   });
 });


### PR DESCRIPTION
Overlooked really basic part of the test, the 403 forbiddens from API Gateway don't have bodies saying unauthroized....