### PR TITLE
fix: Remove int tests from run as none present

### DIFF
--- a/chat/run-tests.sh
+++ b/chat/run-tests.sh
@@ -13,7 +13,6 @@ cd /tests
 echo "Running tests in ${TEST_ENVIRONMENT}"
 
 nx run chat:test:acc 
-nx run chat:test:int 
 
 echo "Finished running tests in ${TEST_ENVIRONMENT}"
 


### PR DESCRIPTION
 fix: Remove int tests from run as none present causes failure exit status by vitest when none found