### PR TITLE
Fixing failure to run acc tests

### DIFF
--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -11,7 +11,7 @@ WORKDIR /tests
 
 COPY package.json package-lock.json tsconfig.json tsconfig.base.json nx.json vitest.config.ts ./
 COPY ./scripts ./scripts
-COPY ./services/auth ./auth
+COPY ./services/auth ./services/auth
 
 COPY ./services/auth/run-tests.sh /run-tests.sh
 # Fix line endings if necessary

--- a/Dockerfile.chat
+++ b/Dockerfile.chat
@@ -11,7 +11,7 @@ WORKDIR /tests
 
 COPY package.json package-lock.json tsconfig.json tsconfig.base.json nx.json vitest.config.ts ./
 COPY ./scripts ./scripts
-COPY ./services/chat ./chat
+COPY ./services/chat ./services/chat
 
 COPY ./services/chat/run-tests.sh /run-tests.sh
 # Fix line endings if necessary


### PR DESCRIPTION
Adjusting dockerfiles for testing image to build on same folder structure so nx testing commands run on them are pointing to valid files.