### PR TITLE
feat: add cloudwatch alarms for the revoke endpoint

### DIFF
--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -720,6 +720,46 @@ Resources:
         - Key: System
           Value: Authentication
 
+  CloudwatchAlarmRevokeToken4xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-revoke-refresh-token-4xx-errors
+      AlarmDescription: !Sub |
+        Alarm detects a high rate of client-side errors.
+        See resolution steps in runbook:
+        {{resolve:ssm:/${ConfigStackName}/runbook-links/prefix}}/pages/4544724994/Runbook+Attestation+API+Gateway+alarms
+      Namespace: AWS/ApiGateway
+      Statistic: Average
+      ActionsEnabled: true
+      MetricName: 4XXError
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 0.05
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: ApiName
+          Value: !Ref AttestationProxyApi
+        - Name: Resource
+          Value: /oauth2/revoke
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Method
+          Value: POST
+      AlarmActions:
+        - !Ref CloudWatchAlarmTopicPagerDuty
+      OKActions:
+        - !Ref CloudWatchAlarmTopicPagerDuty
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
+
+
   CloudWatchAlarmTopicPagerDuty:
     Type: AWS::SNS::Topic
     Properties:
@@ -1639,6 +1679,7 @@ Resources:
         - ScopeDescription: Shared signal scope for resource server
           ScopeName: !Ref CustomScopeName
 
+ 
   # Shared signal user pool client
   CognitoM2MClient:
     Condition: IsNotProduction
@@ -2988,6 +3029,9 @@ Outputs:
 
   CloudwatchAlarmAuthProxy4xxErrors:
     Value: !Ref CloudwatchAlarmAuthProxy4xxErrors
+
+  CloudwatchAlarmRevokeToken4xxErrors:
+    Value: !Ref CloudwatchAlarmRevokeToken4xxErrors
 
   AuthProxyId:
     Value: !Ref AttestationProxyApi

--- a/services/auth/tests/common/config.ts
+++ b/services/auth/tests/common/config.ts
@@ -19,6 +19,7 @@ const getTestConfig = () => {
     'CFN_CloudwatchAlarmAuthProxy4xxErrors',
     'CFN_CloudwatchAlarmAuthProxy5xxErrors',
     'CFN_CloudwatchAlarmAuthProxyLatencyErrors',
+    'CFN_CloudwatchAlarmRevokeToken4xxErrors',
     'CFN_SlackSupportChannelConfigurationARN',
     'CFN_CognitoSecretName',
     'CFN_SharedSignalClientId',
@@ -106,6 +107,8 @@ const getTestConfig = () => {
       process.env.CFN_CloudwatchAlarmAuthProxy5xxErrors!,
     cloudWatchAlarmAuthProxyLatencyErrors:
       process.env.CFN_CloudwatchAlarmAuthProxyLatencyErrors!,
+    cloudWatchAlarmRevokeToken4xxErrors:
+      process.env.CFN_CloudwatchAlarmRevokeToken4xxErrors!,
     cognitoSecretName: process.env.CFN_CognitoSecretName!,
     authProxyId: process.env.CFN_AuthProxyId!,
     environment: process.env.TEST_ENVIRONMENT,

--- a/services/auth/tests/int/attestation-cloudwatch-alarms.test.ts
+++ b/services/auth/tests/int/attestation-cloudwatch-alarms.test.ts
@@ -12,6 +12,7 @@ const alarmsToTest = [
   testConfig.cloudWatchAlarmAuthProxy4xxErrors,
   testConfig.cloudWatchAlarmAuthProxy5xxErrors,
   testConfig.cloudWatchAlarmAuthProxyLatencyErrors,
+  testConfig.cloudWatchAlarmRevokeToken4xxErrors,
   testConfig.authProxyWAFAlarm,
 ];
 

--- a/services/auth/tests/unit/attestation-cloudwatch-alarms.test.ts
+++ b/services/auth/tests/unit/attestation-cloudwatch-alarms.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { loadTemplateFromFile } from '../common/template';
-import { testConfig } from '../common/config';
 import path from 'path';
 import { AlarmTestCase } from './alarm-test-case';
 
@@ -76,6 +75,32 @@ const testCases: AlarmTestCase[] = [
     threshold: 2500,
     comparisonOperator: 'GreaterThanOrEqualToThreshold',
     dimensions: [{ Name: 'ApiName', Value: { Ref: 'AttestationProxyApi' } }],
+  },
+  {
+    name: '4xx',
+    alarmName: `revoke-refresh-token-4xx-errors`,
+    actionsEnabled: true,
+    namespace: 'AWS/ApiGateway',
+    alarmResource: 'CloudwatchAlarmRevokeToken4xxErrors',
+    topicResource: 'CloudWatchAlarmTopicPagerDuty',
+    subscriptionResource: 'CloudWatchAlarmTopicSubscriptionPagerDuty',
+    topicPolicyResource: 'CloudWatchAlarmPublishToTopicPolicy',
+    slackChannelConfigurationResource: 'SlackSupportChannelConfiguration',
+    metricName: '4XXError',
+    alarmDescription: 'Alarm detects a high rate of client-side errors.',
+    topicDisplayName: 'cloudwatch-alarm-topic',
+    statistic: 'Average',
+    period: 60,
+    evaluationPeriods: 5,
+    datapointsToAlarm: 5,
+    threshold: 0.05,
+    comparisonOperator: 'GreaterThanThreshold',
+    dimensions: [
+      { Name: 'ApiName', Value: { Ref: 'AttestationProxyApi' } },
+      { Name: 'Resource', Value: '/oauth2/revoke' },
+      { Name: 'Stage', Value: { Ref: 'Environment' } },
+      { Name: 'Method', Value: 'POST' },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Description

This PR adds CloudWatch Alarms for the `oauth2/revoke` endpoint.

### Ticket number

[GOVUKAPP-2419]

