### PR TITLE
feat: SSM Param call for feature flag on attestation

### DIFF
--- a/services/auth/proxy/feature-flags.ts
+++ b/services/auth/proxy/feature-flags.ts
@@ -1,8 +1,23 @@
+import { getParameter } from '@aws-lambda-powertools/parameters/ssm';
+
+const fetchFeatureFlag = async (flagName: string): Promise<boolean> => {
+  const configStackName = process.env['CONFIG_STACK_NAME'];
+  if (configStackName == null) {
+    throw new Error('Missing Environment Variable: CONFIG_STACK_NAME');
+  }
+  const paramaterPath = `/${configStackName}/feature-flags/${flagName}`;
+  const parameter = await getParameter(paramaterPath, { maxAge: 900 }); //Caching for 15 minutes
+  if (parameter == null) {
+    throw new Error(`Missing SSM Paramater at: ${paramaterPath}`);
+  }
+  return parameter.toLowerCase() === 'true';
+};
+
 export interface FeatureFlags {
-  ATTESTATION: boolean;
+  ATTESTATION: () => Promise<boolean>;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const FEATURE_FLAGS: FeatureFlags = {
-  ATTESTATION: process.env['ENABLE_ATTESTATION'] === 'true',
+  ATTESTATION: async () => fetchFeatureFlag('attestation'),
 };

--- a/services/auth/proxy/handler.ts
+++ b/services/auth/proxy/handler.ts
@@ -45,6 +45,7 @@ export const createHandler =
         getConfig,
       } = dependencies;
       const config = await getConfig();
+      const isAttestationEnabled = await featureFlags.ATTESTATION();
 
       const { headers, body, httpMethod, path } = event;
 
@@ -60,10 +61,10 @@ export const createHandler =
 
       const sanitizedHeaders = await sanitizeHeaders(
         headers,
-        featureFlags.ATTESTATION,
+        isAttestationEnabled,
       );
 
-      if (featureFlags.ATTESTATION) {
+      if (isAttestationEnabled) {
         await attestationUseCase.validateAttestationHeaderOrThrow(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
           sanitizedHeaders as SanitizedRequestHeadersWithAttestation,

--- a/services/auth/proxy/tests/unit/feature-flags.unit.test.ts
+++ b/services/auth/proxy/tests/unit/feature-flags.unit.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FEATURE_FLAGS } from '../../feature-flags';
+import { afterEach } from 'node:test';
+import { getParameter } from '@aws-lambda-powertools/parameters/ssm';
+import { V } from 'vitest/dist/chunks/reporters.d.BFLkQcL6.js';
+
+const mockConfigStackName = 'test-ssm';
+
+vi.mock('@aws-lambda-powertools/parameters/ssm', async (importOriginal) => {
+  const originalModule = await importOriginal<
+    typeof import('@aws-lambda-powertools/parameters/ssm')
+  >();
+  return {
+    ...originalModule,
+    getParameter: vi.fn().mockResolvedValue('True'),
+  };
+});
+
+describe('feature flags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('GIVEN CONFIG_STACK_NAME is missing', async () => {
+    it('THEN an error is thrown', () => {
+      const flags = FEATURE_FLAGS;
+      expect(flags.ATTESTATION()).rejects.toThrow(
+        'Missing Environment Variable: CONFIG_STACK_NAME',
+      );
+    });
+  });
+
+  describe('GIVEN no SSM Flag is found', async () => {
+    beforeEach(() => {
+      vi.mocked(getParameter).mockResolvedValue(undefined);
+      vi.stubEnv('CONFIG_STACK_NAME', mockConfigStackName);
+    });
+
+    it('THEN an error is thrown', () => {
+      const flags = FEATURE_FLAGS;
+      expect(flags.ATTESTATION()).rejects.toThrow(
+        `Missing SSM Paramater at: /test-ssm/feature-flags/attestation`,
+      );
+    });
+  });
+
+  describe('GIVEN a call for the attestation flag', () => {
+    const scenarios = [
+      {
+        outcome: false,
+        parameterValue: 'False',
+      },
+      {
+        outcome: true,
+        parameterValue: 'True',
+      },
+    ];
+    it.each(scenarios)(
+      'THEN $outcome is returned when the parameter value is $parameterValue',
+      async ({ outcome, parameterValue }) => {
+        vi.mocked(getParameter).mockResolvedValue(parameterValue);
+
+        const flags = FEATURE_FLAGS;
+        expect(flags.ATTESTATION()).resolves.toEqual(outcome);
+      },
+    );
+  });
+});

--- a/services/auth/proxy/tests/unit/feature-flags.unit.test.ts
+++ b/services/auth/proxy/tests/unit/feature-flags.unit.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FEATURE_FLAGS } from '../../feature-flags';
 import { afterEach } from 'node:test';
 import { getParameter } from '@aws-lambda-powertools/parameters/ssm';
-import { V } from 'vitest/dist/chunks/reporters.d.BFLkQcL6.js';
 
 const mockConfigStackName = 'test-ssm';
 

--- a/services/auth/proxy/tests/unit/handler.unit.test.ts
+++ b/services/auth/proxy/tests/unit/handler.unit.test.ts
@@ -69,7 +69,7 @@ describe('lambdaHandler', () => {
     },
     proxy: mockProxy,
     featureFlags: {
-      ATTESTATION: true,
+      ATTESTATION: vi.fn().mockReturnValue(true),
     },
     getClientSecret: vi.fn(),
     getConfig: vi.fn().mockReturnValue({
@@ -95,7 +95,9 @@ describe('lambdaHandler', () => {
   const disableAttestationEvent = createHandler(
     createMockDependencies({
       featureFlags: {
-        ATTESTATION: false,
+        ATTESTATION: vi.fn(() => {
+          return false;
+        }),
       },
     }),
   );

--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -1524,7 +1524,7 @@ Resources:
       KmsKeyArn: !GetAtt AuthProxyFunctionKMSKey.Arn
       Environment:
         Variables:
-          ENABLE_ATTESTATION: !Sub '{{resolve:ssm:/${ConfigStackName}/feature-flags/attestation}}'
+          CONFIG_STACK_NAME: !Ref ConfigStackName
           COGNITO_URL: !Join
             - ''
             - - https://


### PR DESCRIPTION
## Description

Moving attestation feature flag retrieval to a cached SSM parameter call (Set to 15 minutes cache duration) instead of an Env Var to enable live changing of the value. 

### Ticket number

[GOVUKAPP-1744]

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**

- [x] I have installed and run pre-commit following guidance in README.md

- [ ] I have updated the changelog

- [x] I have tested this and added output to Jira
      **_Comment:_**

- [ ] Automated tests added
      **_Comment:_**

- [ ] Documentation added ([link]())
      **_Comment:_**

- [ ] Delete any new stacks created for this ticket
      **_Comment:_**

- [ ] Running SAM tests (If so, please ensure `[run-sam-tests]` is in your commit.)

### Co-authored by


[GOVUKAPP-1744]: https://govukverify.atlassian.net/browse/GOVUKAPP-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ