### PR TITLE
chore: pin actions/* to their commit shas

### DIFF
--- a/.github/workflows/auth-post-merge.yaml
+++ b/.github/workflows/auth-post-merge.yaml
@@ -30,23 +30,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b3498302c5c423fa896b97a26bb183df735d08f8 # v4.3.0
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63 # v2
         with:
           use-installer: true # this caches installation but is only available on Linux x86-64 runners
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1v4
         with:
           role-to-assume: ${{ vars.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/chat-post-merge.yaml
+++ b/.github/workflows/chat-post-merge.yaml
@@ -30,23 +30,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b3498302c5c423fa896b97a26bb183df735d08f8 # v4.3.0
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63 # v2
         with:
           use-installer: true # this caches installation but is only available on Linux x86-64 runners
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1v4
         with:
           role-to-assume: ${{ vars.CHAT_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,21 +20,21 @@ jobs:
       checks: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b3498302c5c423fa896b97a26bb183df735d08f8 # v4.3.0
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up SAM cli
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63 # v2
         with:
           use-installer: true
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 22
           cache: 'npm'
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.8
       - run: pip install checkov

--- a/.github/workflows/version-tracker.yaml
+++ b/.github/workflows/version-tracker.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b3498302c5c423fa896b97a26bb183df735d08f8 # v4.3.0
 
       - name: Setup SSH for private repos
         run: |


### PR DESCRIPTION
## Description

This PR addresses the security concern around actions/* not being pinned to their commit shas, see [here](https://docs.github.com/en/actions/reference/security/secure-use#potential-impact-of-a-compromised-runner) for more info around this attack vector.

