### PR TITLE
chore: remove shield advanced as this is implemented elsewhere

### DIFF
--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -2530,20 +2530,6 @@ Resources:
         - !GetAtt SharedSignalWafLogGroup.Arn
       ResourceArn: !GetAtt SharedSignalWAF.Arn
 
-  ShieldProtection:
-    Condition: IsNotProduction
-    Type: AWS::Shield::Protection
-    Properties:
-      Name: !Sub ${AWS::StackName}-shared-signal-shield-protection
-      ResourceArn: !Sub arn:aws:route53:::hostedzone/{{resolve:ssm:/dns/env-hosted-zone-id}}
-      Tags:
-        - Key: Product
-          Value: GOV.UK
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: System
-          Value: Authentication
-    
   RevokeRefreshTokenFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/services/auth/tests/unit/shared-signals-domain.unit.test.ts
+++ b/services/auth/tests/unit/shared-signals-domain.unit.test.ts
@@ -41,16 +41,4 @@ describe('shared signal domain', () => {
       },
     });
   });
-
-  it('should have shield protection for the shared signal domain', () => {
-    template.hasResourceProperties('AWS::Shield::Protection', {
-      Name: {
-        'Fn::Sub': '${AWS::StackName}-shared-signal-shield-protection',
-      },
-      ResourceArn: {
-        'Fn::Sub':
-          'arn:aws:route53:::hostedzone/{{resolve:ssm:/dns/env-hosted-zone-id}}',
-      },
-    });
-  });
 });


### PR DESCRIPTION
## Description

This PR removes the need for AWS Shield Advanced at environment level as it is covered elsewhere, see [here](https://gds.slack.com/archives/C049ASDACJV/p1757322144957219) for more info
### Ticket number

[GOVUKAPP-1755]




[GOVUKAPP-1755]: https://govukverify.atlassian.net/browse/GOVUKAPP-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ