### PR TITLE
fix: removed 4XX alarm & forced changeset existing alarms to fix SNS topic error

### DIFF
--- a/services/chat/template.yaml
+++ b/services/chat/template.yaml
@@ -30,9 +30,9 @@ Parameters:
     Description: Stack Name for Config Stack
     Default: govuk-app-config
   
-  AuthStackName:
+  AppBackendStackName:
     Type: String
-    Description: Stack Name for Auth Stack
+    Description: Stack Name for GovUK APP Auth Stack
     Default: govuk-app-backend
   
 
@@ -534,41 +534,6 @@ Resources:
         - Key: System
           Value: Chat
 
-
-  CloudwatchAlarmChatProxy4xxErrors:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub ${AWS::StackName}-chat-proxy-4xx-errors
-      AlarmDescription: !Sub |
-        Alarm detects a high rate of client-side errors.
-        See resolution steps in runbook:
-        {{resolve:ssm:/${ConfigStackName}/runbook-links/prefix}}/pages/4613701633/Runbook+Chat+API+Gateway+alarms
-      Namespace: AWS/ApiGateway
-      Statistic: Average
-      ActionsEnabled: true
-      MetricName: 4XXError
-      Period: 60
-      EvaluationPeriods: 5
-      DatapointsToAlarm: 5
-      Threshold: 0.05
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: ApiName
-          Value: !Sub ${AWS::StackName}-chat-proxy
-        - Name: Stage
-          Value: !Ref Environment
-      AlarmActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic'
-      OKActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic'
-      Tags:
-        - Key: Product
-          Value: GOV.UK
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: System
-          Value: Chat
-
   CloudwatchAlarmChatProxy5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -592,9 +557,9 @@ Resources:
         - Name: Stage
           Value: !Ref Environment
       AlarmActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic'
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AppBackendStackName}-cloudwatch-alarm-topic'
       OKActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic'
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AppBackendStackName}-cloudwatch-alarm-topic'
       Tags:
         - Key: Product
           Value: GOV.UK
@@ -628,9 +593,9 @@ Resources:
         - Name: Region
           Value: !Ref AWS::Region
       AlarmActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic'
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AppBackendStackName}-cloudwatch-alarm-topic'
       OKActions:
-        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic'
+        - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AppBackendStackName}-cloudwatch-alarm-topic'
       Tags:
         - Key: Product
           Value: GOV.UK
@@ -650,7 +615,7 @@ Outputs:
 
   AuthStackName:
     Description: The name of the Auth stack
-    Value: !Ref AuthStackName
+    Value: !Ref AppBackendStackName
 
   StackName:
     Description: The name of the CloudFormation stack

--- a/services/chat/tests/infra/api-gateway-alarms.unit.test.ts
+++ b/services/chat/tests/infra/api-gateway-alarms.unit.test.ts
@@ -9,29 +9,6 @@ const template = loadTemplateFromFile(
 
 const testCases: AlarmTestCase[] = [
   {
-    name: '4xx',
-    alarmName: `chat-proxy-4xx-errors`,
-    actionsEnabled: true,
-    namespace: 'AWS/ApiGateway',
-    alarmResource: 'CloudwatchAlarmChatProxy4xxErrors',
-    metricName: '4XXError',
-    alarmDescription: 'Alarm detects a high rate of client-side errors.',
-    topicResource: {
-      'Fn::Sub':
-        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic',
-    },
-    statistic: 'Average',
-    period: 60,
-    evaluationPeriods: 5,
-    datapointsToAlarm: 5,
-    threshold: 0.05,
-    comparisonOperator: 'GreaterThanThreshold',
-    dimensions: [
-      { Name: 'ApiName', Value: { 'Fn::Sub': '${AWS::StackName}-chat-proxy' } },
-      { Name: 'Stage', Value: { Ref: 'Environment' } },
-    ],
-  },
-  {
     name: '5xx',
     alarmName: `chat-proxy-5xx-errors`,
     actionsEnabled: true,
@@ -41,7 +18,7 @@ const testCases: AlarmTestCase[] = [
     alarmDescription: 'Alarm detects a high rate of server-side errors.',
     topicResource: {
       'Fn::Sub':
-        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic',
+        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AppBackendStackName}-cloudwatch-alarm-topic',
     },
     statistic: 'Average',
     period: 60,

--- a/services/chat/tests/infra/waf-alarms.unit.test.ts
+++ b/services/chat/tests/infra/waf-alarms.unit.test.ts
@@ -19,7 +19,7 @@ const testCases: AlarmTestCase[] = [
       'Alarm when the Chat Proxy WAF rate limit exceeds 300 requests per 5 minutes',
     topicResource: {
       'Fn::Sub':
-        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AuthStackName}-cloudwatch-alarm-topic',
+        'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${AppBackendStackName}-cloudwatch-alarm-topic',
     },
     statistic: 'Sum',
     extendedStatistic: undefined,


### PR DESCRIPTION
## Description

Bug fix:

1. Removed 4XX alarm (Will fire on expected behaviour presently)
2. Parameter name change -> Forces changeset update on other alarms to mend the broken SNS topic name
3. Fixed tests.

### Ticket number

[GOVUKAPP-2662]
