### PR TITLE
Fix: drifted resources

### DIFF
--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -38,6 +38,11 @@ Parameters:
     Description: Stack Name for Config Stack
     Default: govuk-app-config
 
+  LogRetentionInDays:
+    Type: AWS::SSM::Parameter::Value<Number>
+    Description: SSM parameter path that resolves to the desired CloudWatch Logs retention in days
+    Default: /govuk-app-config/log-retention/in-days
+
   TestRoleArn:
     Type: String
     Description: The ARN of the role that will used for integration tests
@@ -426,7 +431,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub aws-waf-logs-cognito-${AWS::StackName}
       KmsKeyId: !GetAtt CognitoWAFLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       Tags:
         - Key: Product
           Value: GOV.UK
@@ -1178,7 +1183,7 @@ Resources:
       # log stream must start with aws-waf-logs-
       LogGroupName: !Sub aws-waf-logs-attestation-${AWS::StackName}
       KmsKeyId: !GetAtt AuthProxyWAFLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -1291,7 +1296,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/api-gateway/${AWS::StackName}-attestation-proxy-api
       KmsKeyId: !GetAtt AttestationProxyApiAccessLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: AttestationProxyApiAccessLogGroupProtectionPolicy
         Description: Protect basic types of sensitive data
@@ -1610,7 +1615,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-auth-proxy-function
       KmsKeyId: !GetAtt AuthProxyFunctionLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -1878,7 +1883,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub /aws/api-gateway/${AWS::StackName}-shared-signal
       KmsKeyId: !GetAtt SharedSignalAccessLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -2038,7 +2043,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-shared-signal-authorizer-function
       KmsKeyId: !GetAtt SharedSignalAuthorizerLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -2225,7 +2230,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-shared-signal-receiver-function
       KmsKeyId: !GetAtt SharedSignalReceiverFunctionLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -2485,7 +2490,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-shared-signal-health-check-function
       KmsKeyId: !GetAtt SharedSignalHealthCheckFunctionLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -2753,7 +2758,7 @@ Resources:
       # must starts with aws-waf-logs-
       LogGroupName: !Sub aws-waf-logs-shared-signal-${AWS::StackName}
       KmsKeyId: !GetAtt SharedSignalWafLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -2869,7 +2874,7 @@ Resources:
       LogGroupClass: STANDARD
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-revoke-refresh-token-function
       KmsKeyId: !GetAtt RevokeRefreshTokenFunctionLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data

--- a/services/auth/tests/unit/attestation.unit.test.ts
+++ b/services/auth/tests/unit/attestation.unit.test.ts
@@ -253,7 +253,7 @@ describe('waf', () => {
 
     it('has a retention policy of 30 days', () => {
       expect(logGroup.Properties.RetentionInDays).toEqual({
-        'Fn::Sub': '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}',
+        Ref: 'LogRetentionInDays',
       });
     });
 

--- a/services/auth/tests/unit/cognito-waf-log-group.unit.test.ts
+++ b/services/auth/tests/unit/cognito-waf-log-group.unit.test.ts
@@ -21,7 +21,7 @@ describe('Set up the Cognito WAF Log Group for GovUK app', () => {
   it('has a retention policy of 30 days', () => {
     template.hasResourceProperties('AWS::Logs::LogGroup', {
       RetentionInDays: {
-        'Fn::Sub': '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}',
+        Ref: 'LogRetentionInDays',
       },
     });
   });

--- a/services/auth/tests/unit/lambda-log-group.unit.test.ts
+++ b/services/auth/tests/unit/lambda-log-group.unit.test.ts
@@ -53,7 +53,7 @@ describe.each(cases)(
 
     it('should use retention from SSM parameter', () => {
       expect(lg.Properties.RetentionInDays).toEqual({
-        'Fn::Sub': '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}',
+        Ref: 'LogRetentionInDays',
       });
     });
 

--- a/services/auth/tests/unit/shared-signal-waf.test.ts
+++ b/services/auth/tests/unit/shared-signal-waf.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { loadTemplateFromFile } from '../common/template';
-import path, { join } from 'path';
+import path from 'path';
 
 const template = loadTemplateFromFile(
   path.join(__dirname, '..', '..', 'template.yaml'),
@@ -158,7 +158,7 @@ describe('Shared Signal WAF logging', () => {
 
   it('has a retention policy of 30 days', () => {
     expect(wafLogGroup.Properties.RetentionInDays).toEqual({
-      'Fn::Sub': '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}',
+      Ref: 'LogRetentionInDays',
     });
   });
 

--- a/services/chat/template.yaml
+++ b/services/chat/template.yaml
@@ -35,6 +35,10 @@ Parameters:
     Description: Stack Name for GovUK APP Auth Stack
     Default: govuk-app-backend
   
+  LogRetentionInDays:
+    Type: AWS::SSM::Parameter::Value<Number>
+    Description: SSM parameter path that resolves to the desired CloudWatch Logs retention in days
+    Default: /govuk-app-config/log-retention/in-days
 
 Conditions:
   UseCodeSigning: !Not
@@ -141,7 +145,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/api-gateway/${AWS::StackName}-chat-proxy-access-logs
       KmsKeyId: !GetAtt ChatApiGatewayAccessLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data
@@ -288,7 +292,7 @@ Resources:
       # log stream must start with aws-waf-logs-
       LogGroupName: !Sub aws-waf-logs-chat-proxy-${AWS::StackName}
       KmsKeyId: !GetAtt ChatApiGatewayWafLogGroupKMSKey.Arn
-      RetentionInDays: !Sub '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}'
+      RetentionInDays: !Ref LogRetentionInDays
       DataProtectionPolicy:
         Name: CloudWatchLogs-PersonalInformation-Protection
         Description: Protect basic types of sensitive data

--- a/services/chat/tests/infra/api-gateway-waf-log-group.unit.test.ts
+++ b/services/chat/tests/infra/api-gateway-waf-log-group.unit.test.ts
@@ -33,9 +33,9 @@ describe('Chat API Gateway WAF Log Group', () => {
     });
   });
 
-  it('should have a parameterized retention policy from SSM', () => {
+  it('should have a retention policy from SSM parameter', () => {
     expect(resourceUnderTest.Properties.RetentionInDays).toEqual({
-      'Fn::Sub': '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}',
+      Ref: 'LogRetentionInDays',
     });
   });
 

--- a/services/chat/tests/infra/api-gateway.unit.test.ts
+++ b/services/chat/tests/infra/api-gateway.unit.test.ts
@@ -192,9 +192,9 @@ describe('Chat API Gateway Access Log Group', () => {
       'Fn::Sub': '/aws/api-gateway/${AWS::StackName}-chat-proxy-access-logs',
     });
   });
-  it('should have a parameterized retention policy from SSM', () => {
+  it('should have a retention policy from SSM parameter', () => {
     expect(resourceUnderTest.Properties.RetentionInDays).toEqual({
-      'Fn::Sub': '{{resolve:ssm:/${ConfigStackName}/log-retention/in-days}}',
+      Ref: 'LogRetentionInDays',
     });
   });
   it('should have a KMS key for encryption', () => {


### PR DESCRIPTION
- CloudFormation won’t re-apply properties just because the backing SSM parameter changed. Dynamic references are resolved at deploy/update time, but unless CloudFormation detects a change to the resource’s properties in the template/parameters, the stack update is a no-op and the existing log group retention stays as-is.

