### PR TITLE
fix: only assert the callback url contains the govuk mobile callback url

### DIFF
--- a/services/auth/tests/acc/cognito-client-oidc.test.ts
+++ b/services/auth/tests/acc/cognito-client-oidc.test.ts
@@ -118,11 +118,10 @@ describe('Check deployed Cognito User Pool Client', async () => {
   });
 
   it('has callback URLs set correctly', () => {
-    const expectedCallbackURLs = [
+    assert.include(
+      userPoolClient.CallbackURLs ?? [],
       'govuk://govuk/login-auth-callback',
-      'https://d84l1y8p4kdic.cloudfront.net', // used for testing purposes
-    ];
-    assert.deepEqual(userPoolClient.CallbackURLs, expectedCallbackURLs);
+    );
   });
 
   it('has logout URL set correctly', () => {


### PR DESCRIPTION
## Description

Fix the callback URL assertion in the Cognito User Pool Client acceptance test to use `assert.include` instead of `assert.deepEqual`, so the test passes in environments (e.g. staging) that have additional callback URLs configured alongside the required `govuk://govuk/login-auth-callback` entry.

### Ticket number

[GOVUKAPP-XXX]

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**
      The change relaxes an over-constrained assertion — it still verifies the required callback URL is present, but no longer fails when additional URLs (e.g. localhost, CloudFront) exist in non-production environments.

- [ ] I have installed and run pre-commit following guidance in README.md

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
      **_Comment:_**

- [x] Automated tests added
      **_Comment:_** Test assertion updated in `services/auth/tests/acc/cognito-client-oidc.test.ts`

- [ ] Documentation added ([link]())
      **_Comment:_** N/A — test-only change

- [ ] Delete any new stacks created for this ticket
      **_Comment:_** N/A

- [ ] Running SAM tests (If so, please ensure `[run-sam-tests]` is in your commit.)

### Co-authored by
