### PR TITLE
Feat/smoke testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,29 +4,29 @@
 version: 2
 updates:
   # Enables version updates for pnpm
-  - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     # Create a group of dependencies to be updated together in one pull request
     groups:
       dependencies:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "patch"
-          - "minor"
+          - 'patch'
+          - 'minor'
 
   # Enables version updates for github actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     # Create a group of dependencies to be updated together in one pull request
     groups:
       dependencies:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "patch"
-          - "minor"
+          - 'patch'
+          - 'minor'

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "jose": "^6.2.2",
         "jsonwebtoken": "^9.0.3",
         "jwk-to-pem": "^2.0.7",
+        "tough-cookie": "^4.1.3",
         "yaml-cfn": "^0.3.2",
         "zod": "^4.3.6"
       },
@@ -15727,6 +15728,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -15742,7 +15755,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15826,6 +15838,12 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -16027,6 +16045,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -17139,28 +17163,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tldts-core": "^7.0.28"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -17195,17 +17197,18 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
-        "tldts": "^7.0.5"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -17551,6 +17554,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -17625,6 +17637,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jose": "^6.2.2",
     "jsonwebtoken": "^9.0.3",
     "jwk-to-pem": "^2.0.7",
+    "tough-cookie": "^4.1.3",
     "yaml-cfn": "^0.3.2",
     "zod": "^4.3.6"
   },

--- a/services/auth/smoke-test/app.ts
+++ b/services/auth/smoke-test/app.ts
@@ -1,0 +1,193 @@
+import { randomBytes } from 'crypto';
+import middy from '@middy/core';
+// eslint-disable-next-line importPlugin/no-internal-modules
+import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware';
+// eslint-disable-next-line importPlugin/no-internal-modules
+import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware';
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import {
+  CloudWatchClient,
+  PutMetricDataCommand,
+} from '@aws-sdk/client-cloudwatch';
+
+import type { ServiceAccount } from 'firebase-admin/app';
+import { cert, getApps, initializeApp } from 'firebase-admin/app';
+// eslint-disable-next-line importPlugin/no-internal-modules
+import { getAppCheck } from 'firebase-admin/app-check';
+import zod from 'zod/v4';
+import { AxiosAuthDriver } from '../tests/driver/axiosAuth.driver';
+import type { ScheduledEvent } from 'aws-lambda';
+import { getSecret } from '@aws-lambda-powertools/parameters/secrets';
+
+const logger = new Logger({
+  serviceName: process.env['POWERTOOLS_SERVICE_NAME'] ?? 'smoke-test',
+});
+const tracer = new Tracer();
+const cloudwatch = new CloudWatchClient();
+
+const metricNamespace = 'GOVUKMobileAuth';
+const metricName = 'SmokeTestSuccess';
+const metricDimensionName = 'Service';
+const metricDimensionValue = 'Auth';
+const smokeTestSuccessValue = Number(true);
+const smokeTestFailureValue = Number(false);
+
+const configSchema = zod.object({
+  cognitoUrl: zod.string(),
+  authProxyUrl: zod.string(),
+  clientId: zod.string(),
+  redirectUri: zod.string(),
+  oneLoginDomain: zod.string(),
+  userSecretName: zod.string(),
+  firebaseSecretName: zod.string(),
+  firebaseIosAppId: zod.string(),
+});
+
+const parsedConfig = configSchema.safeParse({
+  cognitoUrl: process.env['COGNITO_URL'],
+  authProxyUrl: process.env['AUTH_PROXY_URL'],
+  clientId: process.env['CLIENT_ID'],
+  redirectUri: process.env['REDIRECT_URI'],
+  oneLoginDomain: process.env['ONE_LOGIN_DOMAIN'],
+  userSecretName: process.env['USER_SECRET_NAME'],
+  firebaseSecretName: process.env['FIREBASE_SECRET_NAME'],
+  firebaseIosAppId: process.env['FIREBASE_IOS_APP_ID'],
+});
+
+if (!parsedConfig.success) {
+  throw new Error(zod.prettifyError(parsedConfig.error));
+}
+
+const smokeTestConfig = parsedConfig.data;
+
+let isFirebaseInitialized = false;
+
+/**
+ *
+ */
+async function ensureFirebaseInitialized(): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+  if (isFirebaseInitialized || getApps().length !== 0) {
+    isFirebaseInitialized = true;
+    return;
+  }
+  const serviceAccount = await getSecret(smokeTestConfig.firebaseSecretName, {
+    transform: 'json',
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  initializeApp({ credential: cert(serviceAccount as ServiceAccount) });
+  isFirebaseInitialized = true;
+}
+
+/**
+ *
+ */
+async function getAttestationToken(): Promise<string> {
+  await ensureFirebaseInitialized();
+  const { token } = await getAppCheck().createToken(
+    smokeTestConfig.firebaseIosAppId,
+  );
+  return token;
+}
+
+/**
+ *
+ * @param success
+ */
+async function emitMetric(success: boolean): Promise<void> {
+  await cloudwatch.send(
+    new PutMetricDataCommand({
+      Namespace: metricNamespace,
+      MetricData: [
+        {
+          MetricName: metricName,
+          Value: success ? smokeTestSuccessValue : smokeTestFailureValue,
+          Unit: 'Count',
+          Dimensions: [
+            { Name: metricDimensionName, Value: metricDimensionValue },
+          ],
+        },
+      ],
+    }),
+  );
+}
+
+/** Production smoke test: verifies sign-in and token refresh flows end-to-end. */
+export const lambdaHandler = middy<ScheduledEvent>()
+  .use(captureLambdaHandler(tracer))
+  .use(injectLambdaContext(logger))
+  .handler(async (): Promise<void> => {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    const runId = randomBytes(8).toString('hex');
+    logger.info('smoke test started', { runId });
+
+    try {
+      const user = await getSecret(smokeTestConfig.userSecretName, {
+        transform: 'json',
+      });
+
+      const attestationToken = await getAttestationToken();
+
+      const authDriver = new AxiosAuthDriver(
+        smokeTestConfig.clientId,
+        smokeTestConfig.cognitoUrl,
+        smokeTestConfig.redirectUri,
+        smokeTestConfig.authProxyUrl,
+        '',
+        smokeTestConfig.oneLoginDomain,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      const state = randomBytes(16).toString('hex');
+
+      logger.info('smoke test step', { runId, step: 'sign-in' });
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const { code, code_verifier, returnedState } =
+        await authDriver.loginAndGetCode(user, state);
+
+      if (returnedState !== state) {
+        throw new Error(
+          `State mismatch: expected ${state}, got ${String(returnedState)}`,
+        );
+      }
+
+      logger.info('smoke test step', { runId, step: 'token-exchange' });
+      const tokenResponse = await authDriver.exchangeCodeForTokens({
+        code,
+        code_verifier,
+        attestationHeader: attestationToken,
+      });
+
+      if (typeof tokenResponse.access_token !== 'string') {
+        throw new Error(
+          `Token exchange failed: ${tokenResponse.status.toString()}`,
+        );
+      }
+      if (typeof tokenResponse.refresh_token !== 'string') {
+        throw new Error('Token exchange missing refresh_token');
+      }
+
+      logger.info('smoke test step', { runId, step: 'token-refresh' });
+      const { access_token: refreshedAccessToken } =
+        await authDriver.refreshAccessToken(
+          tokenResponse.refresh_token,
+          attestationToken,
+        );
+
+      if (refreshedAccessToken === tokenResponse.access_token) {
+        throw new Error('Refreshed token matches original');
+      }
+
+      logger.info('smoke test result', { runId, status: 'pass' });
+      await emitMetric(true);
+    } catch (error) {
+      logger.error('smoke test result', {
+        runId,
+        status: 'fail',
+        error: String(error),
+      });
+      await emitMetric(false);
+    }
+  });

--- a/services/auth/smoke-test/app.ts
+++ b/services/auth/smoke-test/app.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 import middy from '@middy/core';
 // eslint-disable-next-line importPlugin/no-internal-modules
 import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware';
@@ -161,12 +161,12 @@ export const lambdaHandler = middy<ScheduledEvent>()
       });
 
       if (typeof tokenResponse.access_token !== 'string') {
-        throw new Error(
+        throw new TypeError(
           `Token exchange failed: ${tokenResponse.status.toString()}`,
         );
       }
       if (typeof tokenResponse.refresh_token !== 'string') {
-        throw new Error('Token exchange missing refresh_token');
+        throw new TypeError('Token exchange missing refresh_token');
       }
 
       logger.info('smoke test step', { runId, step: 'token-refresh' });

--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -4001,6 +4001,279 @@ Resources:
         - Key: System
           Value: Authentication
 
+  SmokeTestFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${AWS::StackName}-smoke-test
+      Description: Production smoke test for sign-in and token refresh flows
+      CodeUri: .build/smoke-test/
+      Handler: app.lambdaHandler
+      Role: !GetAtt SmokeTestFunctionIAMRole.Arn
+      KmsKeyArn: !GetAtt SmokeTestFunctionKMSKey.Arn
+      LoggingConfig:
+        LogGroup: !Ref SmokeTestFunctionLogGroup
+      Events:
+        SmokeTestSchedule:
+          Type: ScheduleV2
+          Name: !Sub ${AWS::StackName}-smoke-test-event-bridge
+          Properties:
+            Name: !Sub ${AWS::StackName}-smoke-test-event
+            PermissionsBoundary: !If
+              - UsePermissionsBoundary
+              - !Ref PermissionsBoundary
+              - !Ref AWS::NoValue
+            ScheduleExpression: rate(5 minutes)
+            RetryPolicy:
+              MaximumRetryAttempts: 2
+              MaximumEventAgeInSeconds: 300
+      Environment:
+        Variables:
+          COGNITO_URL: !Join
+            - ''
+            - - !Sub '{{resolve:ssm:/${ConfigStackName}/cognito/custom-domain}}'
+              - !Sub .auth.${AWS::Region}.amazoncognito.com
+          AUTH_PROXY_URL: !Sub https://${AttestationProxyApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/
+          CLIENT_ID: !Ref CognitoUserPoolClient
+          REDIRECT_URI: https://d84l1y8p4kdic.cloudfront.net
+          ONE_LOGIN_DOMAIN: !If
+            - IsProduction
+            - signin.account.gov.uk
+            - !Sub
+              - signin.${OneLoginEnv}.account.gov.uk
+              - OneLoginEnv: !FindInMap [OneLogin, Environment, !Ref Environment]
+          USER_SECRET_NAME: !Sub /${ConfigStackName}/smoke-test/user # pragma: allowlist secret
+          FIREBASE_SECRET_NAME: !Sub /${ConfigStackName}/firebase/service-account
+          FIREBASE_IOS_APP_ID: !Sub '{{resolve:ssm:/${ConfigStackName}/firebase/appcheck/ios-app-id}}'
+          POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-smoke-test
+          POWERTOOLS_LOGGER_LOG_EVENT: "False"
+      Tags:
+        Product: GOV.UK
+        Environment: !Ref Environment
+        System: Authentication
+
+  SmokeTestFunctionKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS key for smoke test Lambda function environment variables
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - kms:*
+            Resource:
+              - '*'
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+            Resource:
+              - '*'
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
+
+  SmokeTestFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupClass: STANDARD
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}-smoke-test
+      KmsKeyId: !GetAtt SmokeTestFunctionLogGroupKMSKey.Arn
+      RetentionInDays: !FindInMap [LogRetentionByEnv, Environment, !Ref Environment]
+      DataProtectionPolicy:
+        Name: CloudWatchLogs-PersonalInformation-Protection
+        Description: Protect basic types of sensitive data
+        Version: '2021-06-01'
+        Configuration:
+          CustomDataIdentifier:
+            - Name: JWTTokens
+              Regex: e[yw][A-Za-z0-9-_]+\.(?:e[yw][A-Za-z0-9-_]+)?\.[A-Za-z0-9-_]{2,}(?:(?:\.[A-Za-z0-9-_]{2,}){2})?
+            - Name: OneLoginUserId
+              Regex: (?:urn:fdc:gov\.uk:[0-9]{4}):[a-zA-Z0-9_\-]*
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - JWTTokens
+              - OneLoginUserId
+            Operation:
+              Audit:
+                FindingsDestination: {}
+          - Sid: masking-policy
+            DataIdentifier:
+              - arn:aws:dataprotection::aws:data-identifier/EmailAddress
+              - arn:aws:dataprotection::aws:data-identifier/IpAddress
+              - JWTTokens
+              - OneLoginUserId
+            Operation:
+              Deidentify:
+                MaskConfig: {}
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
+
+  SmokeTestFunctionLogGroupKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS key for smoke test Lambda function log group
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - kms:*
+            Resource:
+              - '*'
+          - Effect: Allow
+            Principal:
+              Service: !Sub logs.${AWS::Region}.amazonaws.com
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource:
+              - '*'
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
+
+  SmokeTestFunctionIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-smoke-test-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: SmokeTestFunctionPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue # pragma: allowlist secret
+                Resource:
+                  - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/smoke-test/user-* # pragma: allowlist secret
+                  - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/firebase/service-account-*
+              - Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-smoke-test:*
+              - Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                Resource: '*'
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
+
+  SmokeTestAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-smoke-test-failure
+      AlarmDescription: !Sub |
+        Production smoke test failed for 2 consecutive 5-minute runs (sign-in or token refresh).
+        Check logs: /aws/lambda/${AWS::StackName}-smoke-test
+      ActionsEnabled: false
+      Namespace: GOVUKMobileAuth
+      MetricName: SmokeTestSuccess
+      Dimensions:
+        - Name: Service
+          Value: Auth
+      Statistic: Minimum
+      Period: 300
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+      AlarmActions:
+        - !Ref CloudWatchAlarmWarningsTopic
+      OKActions:
+        - !Ref CloudWatchAlarmWarningsTopic
+      Tags:
+        - Key: Product
+          Value: GOV.UK
+        - Key: Environment
+          Value: !Ref Environment
+        - Key: System
+          Value: Authentication
+
+  SmokeTestDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub ${AWS::StackName}-smoke-test
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0, "y": 0, "width": 24, "height": 6,
+              "properties": {
+                "metrics": [["GOVUKMobileAuth", "SmokeTestSuccess", "Service", "Auth", {"stat": "Minimum", "period": 300}]],
+                "title": "Smoke Test Success (1=pass, 0=fail)",
+                "view": "timeSeries",
+                "region": "${AWS::Region}"
+              }
+            },
+            {
+              "type": "log",
+              "x": 0, "y": 6, "width": 24, "height": 8,
+              "properties": {
+                "query": "SOURCE '/aws/lambda/${AWS::StackName}-smoke-test' | fields @timestamp, runId, step, status, error | sort @timestamp desc | limit 50",
+                "title": "Recent Smoke Test Runs",
+                "view": "table",
+                "region": "${AWS::Region}"
+              }
+            }
+          ]
+        }
+
 Outputs:
   AWSAccountId:
     Description: AWS Account ID

--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -4001,7 +4001,11 @@ Resources:
         - Key: System
           Value: Authentication
 
+  ############################
+  # Smoke Testing Resources
+  ############################
   SmokeTestFunction:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${AWS::StackName}-smoke-test
@@ -4052,6 +4056,7 @@ Resources:
         System: Authentication
 
   SmokeTestFunctionKMSKey:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for smoke test Lambda function environment variables
@@ -4083,6 +4088,7 @@ Resources:
           Value: Authentication
 
   SmokeTestFunctionLogGroup:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupClass: STANDARD
@@ -4127,6 +4133,7 @@ Resources:
           Value: Authentication
 
   SmokeTestFunctionLogGroupKMSKey:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::KMS::Key
     Properties:
       Description: KMS key for smoke test Lambda function log group
@@ -4164,6 +4171,7 @@ Resources:
           Value: Authentication
 
   SmokeTestFunctionIAMRole:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub ${AWS::StackName}-smoke-test-role
@@ -4213,6 +4221,7 @@ Resources:
           Value: Authentication
 
   SmokeTestAlarm:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${AWS::StackName}-smoke-test-failure
@@ -4245,6 +4254,7 @@ Resources:
           Value: Authentication
 
   SmokeTestDashboard:
+    Condition: IsNonIntegratedEnvironment
     Type: AWS::CloudWatch::Dashboard
     Properties:
       DashboardName: !Sub ${AWS::StackName}-smoke-test
@@ -4273,7 +4283,11 @@ Resources:
             }
           ]
         }
-
+  
+  ############################
+  # Smoke Testing Resources End
+  ############################
+  
 Outputs:
   AWSAccountId:
     Description: AWS Account ID

--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -4039,10 +4039,7 @@ Resources:
           AUTH_PROXY_URL: !Sub https://${AttestationProxyApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/
           CLIENT_ID: !Ref CognitoUserPoolClient
           REDIRECT_URI: https://d84l1y8p4kdic.cloudfront.net
-          ONE_LOGIN_DOMAIN: !If
-            - IsProduction
-            - signin.account.gov.uk
-            - !Sub
+          ONE_LOGIN_DOMAIN: !Sub
               - signin.${OneLoginEnv}.account.gov.uk
               - OneLoginEnv: !FindInMap [OneLogin, Environment, !Ref Environment]
           USER_SECRET_NAME: !Sub /${ConfigStackName}/smoke-test/user # pragma: allowlist secret

--- a/services/auth/tests/driver/axiosAuth.driver.ts
+++ b/services/auth/tests/driver/axiosAuth.driver.ts
@@ -31,6 +31,7 @@ export class AxiosAuthDriver implements AuthDriver {
     redirectUri: string,
     proxyUrl: string,
     oneLoginEnvironment: string,
+    oneLoginDomainOverride?: string,
   ) {
     this.clientId = clientId;
     this.authUrl = authUrl;
@@ -40,7 +41,8 @@ export class AxiosAuthDriver implements AuthDriver {
     this.redirectUri = redirectUri;
     this.proxyDomain = new URL(proxyUrl).hostname;
     this.proxyPath = new URL(proxyUrl).pathname;
-    this.oneLoginDomain = `signin.${oneLoginEnvironment}.account.gov.uk`;
+    this.oneLoginDomain =
+      oneLoginDomainOverride ?? `signin.${oneLoginEnvironment}.account.gov.uk`;
     const jar = new CookieJar();
     this.client = wrapper(
       axios.create({
@@ -62,7 +64,10 @@ export class AxiosAuthDriver implements AuthDriver {
     return input.val();
   }
 
-  async loginAndGetCode(input: LoginUserInput): Promise<LoginUserResponse> {
+  async loginAndGetCode(
+    input: LoginUserInput,
+    state = 'debug123',
+  ): Promise<LoginUserResponse> {
     this.clearCookies();
     const { code_verifier, code_challenge } = await pkceChallenge();
     const authorizeEndpoint =
@@ -74,7 +79,7 @@ export class AxiosAuthDriver implements AuthDriver {
         scope: 'openid email',
         code_challenge,
         code_challenge_method: 'S256',
-        state: 'debug123',
+        state,
         idpidentifier: 'onelogin',
       });
 
@@ -120,10 +125,12 @@ export class AxiosAuthDriver implements AuthDriver {
 
     const redirectedUrl = new URL(totpFormResponse.request.res.responseUrl);
     const code = redirectedUrl.searchParams.get('code');
+    const returnedState = redirectedUrl.searchParams.get('state');
 
     return {
       code: code!,
       code_verifier,
+      returnedState,
     };
   }
 

--- a/services/auth/tests/types/user.ts
+++ b/services/auth/tests/types/user.ts
@@ -7,6 +7,7 @@ export interface LoginUserInput {
 export interface LoginUserResponse {
   code: string;
   code_verifier: string;
+  returnedState: string | null;
 }
 
 export type TokenExchangeResponse = {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.sources=./services,./libs
 sonar.exclusions=**/node_modules/**/*,**/package?.json,**/shared-steps/**
 sonar.test.exclusions=**/.nx/cache/**
 sonar.exclusions=**/.nx/cache/**,**/tests/**,**/*.test.ts,**/__mocks__/**,libs/test-utils/**,scripts/**
-sonar.coverage.exclusions=libs/test-utils/**,scripts/**
+sonar.coverage.exclusions=libs/test-utils/**,scripts/**,services/auth/smoke-test/**
 sonar.typescript.lcov.reportPaths=./coverage/lcov.info
 sonar.typescript.tsconfigPaths=./tsconfig.json
 #./services/auth/tsconfig.json,./services/chat/tsconfig.json


### PR DESCRIPTION
  ## Description

Adds an EventBridge-scheduled Lambda that runs the sign-in and token refresh flows against production every 5 minutes. Emits a custom CloudWatch metric (GOVUKMobileAuth/SmokeTestSuccess) and triggers a Slack alert via the existing SNS/Chatbot pipeline after 2 consecutive failures.

Reuses AxiosAuthDriver for the auth flow; extends it with an optional oneLoginDomainOverride param and a parameterised state for CSRF verification. Registers the CloudFront redirect URI on the existing Cognito app client (PKCE-protected, no functional endpoint needed).

## Checklist

- [ ] Is my change backwards compatible? **_Please include evidence_**

- [x] I have installed and run pre-commit following guidance in README.md

- [ ] I have updated the changelog

- [ ] I have tested this and added output to Jira
      **_Comment:_**

- [ ] Automated tests added
      **_Comment:_**

- [ ] Documentation added ([link]())
      **_Comment:_**

- [ ] Delete any new stacks created for this ticket
      **_Comment:_**

- [ ] Running SAM tests (If so, please ensure `[run-sam-tests]` is in your commit.)

### Co-authored by
