### PR TITLE
fix(smoke-test): use registered redirect URI and handle custom scheme…

### DIFF
--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -4060,7 +4060,7 @@ Resources:
               - !Sub .auth.${AWS::Region}.amazoncognito.com
           AUTH_PROXY_URL: !Sub https://${AttestationProxyApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/
           CLIENT_ID: !Ref CognitoUserPoolClient
-          REDIRECT_URI: https://d84l1y8p4kdic.cloudfront.net
+          REDIRECT_URI: govuk://govuk/login-auth-callback
           ONE_LOGIN_DOMAIN: !Sub
               - signin.${OneLoginEnv}.account.gov.uk
               - OneLoginEnv: !FindInMap [OneLogin, Environment, !Ref Environment]

--- a/services/auth/tests/driver/axiosAuth.driver.ts
+++ b/services/auth/tests/driver/axiosAuth.driver.ts
@@ -115,15 +115,37 @@ export class AxiosAuthDriver implements AuthDriver {
 
     const { otp } = await TOTP.generate(input.totpSecret);
 
-    const totpFormResponse = await this.client.post(
-      `https://${this.oneLoginDomain}/enter-authenticator-app-code?`,
-      querystring.stringify({
-        _csrf: csrfToken,
-        code: otp,
-      }),
-    );
+    // Track the last redirect destination across the full chain.
+    // beforeRedirect fires before each hop, so after all HTTP redirects are
+    // exhausted (or axios fails to follow a custom scheme), this holds the
+    // URL containing the auth code.
+    let codeRedirectUrl: string | undefined;
 
-    const redirectedUrl = new URL(totpFormResponse.request.res.responseUrl);
+    try {
+      await this.client.post(
+        `https://${this.oneLoginDomain}/enter-authenticator-app-code?`,
+        querystring.stringify({
+          _csrf: csrfToken,
+          code: otp,
+        }),
+        {
+          beforeRedirect: (
+            _options: Record<string, unknown>,
+            responseDetails: { headers: Record<string, string> },
+          ) => {
+            codeRedirectUrl = responseDetails.headers['location'];
+          },
+        },
+      );
+    } catch (error) {
+      if (!codeRedirectUrl) throw error;
+    }
+
+    if (!codeRedirectUrl) {
+      throw new Error('TOTP step did not produce a redirect to the app');
+    }
+
+    const redirectedUrl = new URL(codeRedirectUrl);
     const code = redirectedUrl.searchParams.get('code');
     const returnedState = redirectedUrl.searchParams.get('state');
 


### PR DESCRIPTION
… redirect

  The smoke test Lambda had REDIRECT_URI hardcoded to a CloudFront URL that
  is only registered as a Cognito callback in dev/staging. In production,
  Cognito only accepts govuk://govuk/login-auth-callback, causing the
  /oauth2/authorize call to return 400 immediately.

  Also fixes the driver to use beforeRedirect to capture the final redirect
  URL across the full chain (One Login → Cognito → govuk://) rather than
  following responseUrl, which only worked when the final destination was a
  reachable HTTP server.

## Tested

Ran the auth script locally and the axios driver would redirect to prod `govuk` app callback. After the change, we can intercept auth code.

