### PR TITLE
fix(smoke-test): use correct One Login domain for production

### DIFF
--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -4061,7 +4061,10 @@ Resources:
           AUTH_PROXY_URL: !Sub https://${AttestationProxyApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/
           CLIENT_ID: !Ref CognitoUserPoolClient
           REDIRECT_URI: govuk://govuk/login-auth-callback
-          ONE_LOGIN_DOMAIN: !Sub
+          ONE_LOGIN_DOMAIN: !If
+            - IsProduction
+            - signin.account.gov.uk
+            - !Sub
               - signin.${OneLoginEnv}.account.gov.uk
               - OneLoginEnv: !FindInMap [OneLogin, Environment, !Ref Environment]
           USER_SECRET_NAME: !Sub /${ConfigStackName}/smoke-test/user # pragma: allowlist secret


### PR DESCRIPTION
  Production's One Login domain has no environment subdomain
  (signin.account.gov.uk), unlike other environments which follow
  the signin.<env>.account.gov.uk pattern.
