### PR TITLE
Chore: Cognito permissions fix + IAM fix for log group

### DIFF
--- a/services/auth/template.yaml
+++ b/services/auth/template.yaml
@@ -3869,6 +3869,10 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                  - cognito-idp:AdminGetUser
+                Resource: !GetAtt CognitoUserPool.Arn
+              - Effect: Allow
+                Action:
                   - secretsmanager:GetSecretValue # pragma: allowlist secret
                 Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${ConfigStackName}/linking/dvla/hash-key-secret-*
               - Effect: Allow
@@ -3877,7 +3881,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: 
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-revoke-refresh-token-function:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-linking-verification-function:*
               - Effect: Allow
                 Action:
                   - xray:PutTraceSegments


### PR DESCRIPTION
Added IAM permissions for the Cognito command to stop the cognito errors. Also fixed the log-group IAM to give stream permissions to the correct log group.

If only this SAM Secure Pipelines had an ephemeral approach so you could test things like this in the PR. Or if my local machine didn't crap the bed with the Nx & TS set up so I could get the local deployment working properly.